### PR TITLE
utils/update utils function name

### DIFF
--- a/docs/source/load cycle counting.ipynb
+++ b/docs/source/load cycle counting.ipynb
@@ -527,7 +527,7 @@
     "\n",
     "**Notes**\n",
     "\n",
-    "The original rainflow counting method in ASTM does not provide any preprocessing method for the sequence data. To get the meaningful results, we provide the `digitizeSequenceToResoultion` function to digitize the input sequence data to a specific resolution, such as 0.5. See the following \"Example with digitized sequence data\"."
+    "The original rainflow counting method in ASTM does not provide any preprocessing method for the sequence data. To get the meaningful results, we provide the `sequenceDigitization` function to digitize the input sequence data to a specific resolution, such as 0.5. See the following \"Example with digitized sequence data\"."
    ]
   },
   {
@@ -668,7 +668,7 @@
    "source": [
     "#### Example with digitized sequence data\n",
     "\n",
-    "This example demonstrates the usage of `digitizeSequenceToResoultion` function before the rainflow counting method. Rainflow counting method counts the number of different load range. Therefore, undigitized sequence data can generate noisy output results. With the `digitizeSequenceToResoultion` function, the output resutls can be aggregated."
+    "This example demonstrates the usage of `sequenceDigitization` function before the rainflow counting method. Rainflow counting method counts the number of different load range. Therefore, undigitized sequence data can generate noisy output results. With the `sequenceDigitization` function, the output resutls can be aggregated."
    ]
   },
   {
@@ -678,7 +678,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ffpack.utils import digitizeSequenceToResoultion"
+    "from ffpack.utils import sequenceDigitization"
    ]
   },
   {
@@ -689,7 +689,7 @@
    "outputs": [],
    "source": [
     "astmRfcSequenceData = [ -2.4, 1.3, -3.3, 4.6, -1.4, 3.2, -4.4, 4.2, -2.1 ]\n",
-    "digitizedAstmRfcSequenceData = digitizeSequenceToResoultion( astmRfcSequenceData, resolution=1.0 )\n",
+    "digitizedAstmRfcSequenceData = sequenceDigitization( astmRfcSequenceData, resolution=1.0 )\n",
     "\n",
     "originalAstmRfcCountingResults = astmRainflowCounting( astmRfcSequenceData )\n",
     "digitizedAstmRfcCountingResults = astmRainflowCounting( digitizedAstmRfcSequenceData )"

--- a/docs/source/utility methods.ipynb
+++ b/docs/source/utility methods.ipynb
@@ -52,7 +52,7 @@
    "source": [
     "---\n",
     "\n",
-    "Function: `getSequencePeakAndValleys`\n",
+    "Function: `sequencePeakAndValleys`\n",
     "\n",
     "Args:\n",
     "\n",
@@ -81,7 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ffpack.utils import getSequencePeakAndValleys"
+    "from ffpack.utils import sequencePeakAndValleys"
    ]
   },
   {
@@ -94,7 +94,7 @@
     "gspvSequenceData = [ -0.5, 0.0, 1.0, -1.0, -2.0, -1.0, 1.5, 3.0, 2.5, -1.0, 0.5, 1.5, 4.5, \n",
     "                     3.5, 1.0, -1.0, -2.5, -1.5, 3.0, 3.5, 1.5, 0.0, -1.5, 0.5, 1.0 ]\n",
     "\n",
-    "gspvResults = getSequencePeakAndValleys( gspvSequenceData, keepEnds=False )"
+    "gspvResults = sequencePeakAndValleys( gspvSequenceData, keepEnds=False )"
    ]
   },
   {
@@ -170,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ffpack.utils import getSequencePeakAndValleys"
+    "from ffpack.utils import sequencePeakAndValleys"
    ]
   },
   {
@@ -183,7 +183,7 @@
     "gspvSequenceData = [ -0.5, 0.0, 1.0, -1.0, -2.0, -1.0, 1.5, 3.0, 2.5, -1.0, 0.5, 1.5, 4.5, \n",
     "                     3.5, 1.0, -1.0, -2.5, -1.5, 3.0, 3.5, 1.5, 0.0, -1.5, 0.5, 1.0 ]\n",
     "\n",
-    "gspvResults = getSequencePeakAndValleys( gspvSequenceData, keepEnds=True )"
+    "gspvResults = sequencePeakAndValleys( gspvSequenceData, keepEnds=True )"
    ]
   },
   {
@@ -259,7 +259,7 @@
    "source": [
     "---\n",
     "\n",
-    "Function: `digitizeSequenceToResoultion`\n",
+    "Function: `sequenceDigitization`\n",
     "\n",
     "Args:\n",
     "\n",
@@ -288,7 +288,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ffpack.utils import digitizeSequenceToResoultion"
+    "from ffpack.utils import sequenceDigitization"
    ]
   },
   {
@@ -300,7 +300,7 @@
    "source": [
     "dstrSequenceData = [ -1.0, 2.3, 1.8, 0.6, -0.4, 0.8, -1.6, -2.5, 3.4, 0.3, 0.1 ]\n",
     "\n",
-    "dstrResults = digitizeSequenceToResoultion( dstrSequenceData, resolution=1.0 )"
+    "dstrResults = sequenceDigitization( dstrSequenceData, resolution=1.0 )"
    ]
   },
   {

--- a/src/ffpack/fdr/minerRule.py
+++ b/src/ffpack/fdr/minerRule.py
@@ -112,11 +112,11 @@ def minerDamageRuleClassic( lccData, snData, fatigueLimit ):
         if p[ 1 ] <= 0:
             raise ValueError( "Counts should be larger than 0" )
     
-    snCurveFitter = utils.SnCurveFitter( snData, fatigueLimit=fatigueLimit )
+    fitterForSnCurve = utils.FitterForSnCurve( snData, fatigueLimit=fatigueLimit )
 
     rst = 0
     for p in lccData:
-        nFromSNCurve = snCurveFitter.getN( p[ 0 ] )
+        nFromSNCurve = fitterForSnCurve.getN( p[ 0 ] )
         if nFromSNCurve != -1: 
             rst += p[ 1 ] / nFromSNCurve
 

--- a/src/ffpack/lcc/astmCounting.py
+++ b/src/ffpack/lcc/astmCounting.py
@@ -164,7 +164,7 @@ def astmSimpleRangeCounting( data ):
         raise ValueError( "Input data length should be at least 2")
 
     # Remove the intermediate value first
-    data = np.array( generalUtils.getSequencePeakAndValleys( data, keepEnds=True ) )
+    data = np.array( generalUtils.sequencePeakAndValleys( data, keepEnds=True ) )
 
     rstDict = defaultdict( int )
     for i, cur in enumerate( data ):
@@ -212,7 +212,7 @@ def astmRainflowCounting( data ):
         raise ValueError( "Input data length should be at least 2")
 
     # Remove the intermediate value first
-    data = np.array( generalUtils.getSequencePeakAndValleys( data, keepEnds=True ) )
+    data = np.array( generalUtils.sequencePeakAndValleys( data, keepEnds=True ) )
 
     dequeA = deque()
     dequeB = deque( [ i for i in data ] )

--- a/src/ffpack/lcc/rychlikCounting.py
+++ b/src/ffpack/lcc/rychlikCounting.py
@@ -70,7 +70,7 @@ def rychlikRainflowCounting( data, aggregate=True ):
 
     # we need to use this util function since it keeps one peak 
     # if there are two or more points together with the same peak value
-    data = generalUtils.getSequencePeakAndValleys( data, keepEnds=True )
+    data = generalUtils.sequencePeakAndValleys( data, keepEnds=True )
     rstSeq = [ ]
     for i in range( 1, len( data ) - 1 ):
         if ( data[ i ] > data[ i - 1 ] and data[ i ] > data[ i + 1 ] ):

--- a/src/ffpack/utils/fdrUtils.py
+++ b/src/ffpack/utils/fdrUtils.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-class SnCurveFitter:
+class FitterForSnCurve:
     '''
     Fit a SN curve based on the experimental data.
     
@@ -25,10 +25,10 @@ class SnCurveFitter:
 
     Examples
     --------
-    >>> from ffpack.utils import snCurveFitter
+    >>> from ffpack.utils import fitterForSnCurve
     >>> data = [ [ 10, 3 ], [ 1000, 1 ] ]
     >>> fatigueLimit = 0.5
-    >>> snCurveFitter = SnCurveFitter( data, fatigueLimit )
+    >>> fitterForSnCurve = FitterForSnCurve( data, fatigueLimit )
     '''
     def __init__( self, data, fatigueLimit ):
         # Edge case check
@@ -73,7 +73,7 @@ class SnCurveFitter:
         
         Examples
         --------
-        >>> rst = snCurveFitter.getN( 2 )
+        >>> rst = fitterForSnCurve.getN( 2 )
         '''
         if S <= 0:
             raise ValueError( "S should be larger than 0" )

--- a/src/ffpack/utils/generalUtils.py
+++ b/src/ffpack/utils/generalUtils.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-def getSequencePeakAndValleys( data, keepEnds=False ):
+def sequencePeakAndValleys( data, keepEnds=False ):
     '''
     Remove the intermediate value and only get the peaks and valleys of the data
 
@@ -31,9 +31,9 @@ def getSequencePeakAndValleys( data, keepEnds=False ):
 
     Examples
     --------
-    >>> from ffpack.utils import getSequencePeakAndValleys
+    >>> from ffpack.utils import sequencePeakAndValleys
     >>> data = [ -0.5, 1.0, -2.0, 3.0, -1.0, 4.5, -2.5, 3.5, -1.5, 1.0 ]
-    >>> rst = getSequencePeakAndValleys( data )
+    >>> rst = sequencePeakAndValleys( data )
     '''
     # Egde cases
     data = np.array( data )
@@ -59,7 +59,7 @@ def getSequencePeakAndValleys( data, keepEnds=False ):
         
     return rst
 
-def digitizeSequenceToResoultion( data, resolution=1.0 ):
+def sequenceDigitization( data, resolution=1.0 ):
     '''
     Digitize the sequence data to a specific resolution
 
@@ -91,9 +91,9 @@ def digitizeSequenceToResoultion( data, resolution=1.0 ):
 
     Examples
     --------
-    >>> from ffpack.utils import digitizeSequenceToResoultion 
+    >>> from ffpack.utils import sequenceDigitization 
     >>> data = [ -1.0, 2.3, 1.8, 0.6, -0.4, 0.8, -1.6, -2.5, 3.4, 0.3, 0.1 ]
-    >>> rst = digitizeSequenceToResoultion( data )
+    >>> rst = sequenceDigitization( data )
     '''
     # Egde cases
     data = np.array( data )

--- a/src/ffpack/utils/lccUtils.py
+++ b/src/ffpack/utils/lccUtils.py
@@ -3,7 +3,7 @@
 import numpy as np
 from collections import defaultdict
 
-def cycleCountingAccordingToBinSize( data, binSize=1.0 ):
+def cycleCountingAggregation( data, binSize=1.0 ):
     '''
     Count number of occurrences of each cycle digitized to the nearest bin.
 
@@ -37,9 +37,9 @@ def cycleCountingAccordingToBinSize( data, binSize=1.0 ):
 
     Examples
     --------
-    >>> from ffpack.utils import cycleCountingAccordingToBinSize
+    >>> from ffpack.utils import cycleCountingAggregation
     >>> data = [ [ 1.7, 2.0 ], [ 2.2, 2.0 ] ]
-    >>> rst = cycleCountingAccordingToBinSize( data )
+    >>> rst = cycleCountingAggregation( data )
     '''
     def getBinKey( value ):
         key = binSize * int( value / binSize )

--- a/tests/fdr/test_fdr_minerRule.py
+++ b/tests/fdr/test_fdr_minerRule.py
@@ -4,7 +4,7 @@ from ffpack import fdr
 import numpy as np
 import pytest
 from unittest.mock import Mock
-from ffpack.utils import SnCurveFitter
+from ffpack.utils import FitterForSnCurve
 
 
 ###############################################################################
@@ -112,8 +112,8 @@ def test_minerDamageRuleClassic_irregularInput_valueError():
 
 def test_minerDamageRuleClassic_twoPairs_scalarOutput():
 
-    snCurveFitter = Mock( SnCurveFitter )
-    snCurveFitter.getN = lambda self, x: { 1: 1000, 2: 100 }[x]
+    fitterForSnCurve = Mock( FitterForSnCurve )
+    fitterForSnCurve.getN = lambda self, x: { 1: 1000, 2: 100 }[x]
 
     lccData = [ [ 1, 100 ], [ 2, 10 ] ]
     snData = [ [ 10, 3 ], [ 1000, 1 ] ]
@@ -126,8 +126,8 @@ def test_minerDamageRuleClassic_twoPairs_scalarOutput():
 
 def test_minerDamageRuleClassic_threePairs_scalarOutput():
 
-    snCurveFitter = Mock( SnCurveFitter )
-    snCurveFitter.getN = lambda self, x: { 1: 100000, 2: 10000, 3: 1000, 4: 100 }[x]
+    fitterForSnCurve = Mock( FitterForSnCurve )
+    fitterForSnCurve.getN = lambda self, x: { 1: 100000, 2: 10000, 3: 1000, 4: 100 }[x]
 
     lccData = [ [ 1, 1000 ], [ 2, 100 ], [ 4, 10 ] ]
     snData = [ [ 10, 5 ], [ 100, 4 ], [ 100000, 1 ] ]
@@ -154,30 +154,30 @@ def test_minerDamageRuleClassic_threePairs_scalarOutput():
 
 def test_minerDamageRuleClassic_threePairsHighFatigueLimit_scalarOutput():
 
-    snCurveFitter = Mock( SnCurveFitter )
+    fitterForSnCurve = Mock( FitterForSnCurve )
     
     lccData = [ [ 1, 1000 ], [ 2, 100 ], [ 4, 10 ] ]
     snData = [ [ 10, 5 ], [ 100, 4 ], [ 100000, 1 ] ]
     fatigueLimit = 1
-    snCurveFitter.getN = lambda self, x: { 1: -1, 2: 10000, 4: 100 }[x]
+    fitterForSnCurve.getN = lambda self, x: { 1: -1, 2: 10000, 4: 100 }[x]
     calRst = fdr.minerDamageRuleClassic( lccData, snData, fatigueLimit )
     expectedRst = 0.11 
     np.testing.assert_allclose( calRst, expectedRst )
 
     fatigueLimit = 2
-    snCurveFitter.getN = lambda self, x: { 1: -1, 2: -1, 4: 100 }[x]
+    fitterForSnCurve.getN = lambda self, x: { 1: -1, 2: -1, 4: 100 }[x]
     calRst = fdr.minerDamageRuleClassic( lccData, snData, fatigueLimit )
     expectedRst = 0.1 
     np.testing.assert_allclose( calRst, expectedRst )
 
     fatigueLimit = 3
-    snCurveFitter.getN = lambda self, x: { 1: -1, 2: -1, 4: 100 }[x]
+    fitterForSnCurve.getN = lambda self, x: { 1: -1, 2: -1, 4: 100 }[x]
     calRst = fdr.minerDamageRuleClassic( lccData, snData, fatigueLimit )
     expectedRst = 0.1 
     np.testing.assert_allclose( calRst, expectedRst )
 
     fatigueLimit = 4
-    snCurveFitter.getN = lambda self, x: { 1: -1, 2: -1, 4: -1 }[x]
+    fitterForSnCurve.getN = lambda self, x: { 1: -1, 2: -1, 4: -1 }[x]
     calRst = fdr.minerDamageRuleClassic( lccData, snData, fatigueLimit )
     expectedRst = 0
     np.testing.assert_allclose( calRst, expectedRst )

--- a/tests/lcc/test_lcc_rychlikCounting.py
+++ b/tests/lcc/test_lcc_rychlikCounting.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 ###############################################################################
 # Test rychlikRainflowCounting function
 ###############################################################################
-@patch( "ffpack.utils.generalUtils.getSequencePeakAndValleys" )
+@patch( "ffpack.utils.generalUtils.sequencePeakAndValleys" )
 def test_rychlikRainflowCounting_twoPoints_empty( mock_get ):
     data = [ 0.0, 2.0 ]
     mock_get.return_value = [ 0.0, 2.0 ]
@@ -22,7 +22,7 @@ def test_rychlikRainflowCounting_twoPoints_empty( mock_get ):
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-@patch( "ffpack.utils.generalUtils.getSequencePeakAndValleys" )
+@patch( "ffpack.utils.generalUtils.sequencePeakAndValleys" )
 def test_rychlikRainflowCounting_threePointsIncreasing_empty( mock_get ):
     data = [ 0.0, 2.0, 3.0 ]
     mock_get.return_value = [ 0.0, 2.0 ]
@@ -36,7 +36,7 @@ def test_rychlikRainflowCounting_threePointsIncreasing_empty( mock_get ):
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-@patch( "ffpack.utils.generalUtils.getSequencePeakAndValleys" )
+@patch( "ffpack.utils.generalUtils.sequencePeakAndValleys" )
 def test_rychlikRainflowCounting_threePointsDecreasing_empty( mock_get ):
     data = [ 3.0, 2.0, 0.0 ]
     mock_get.return_value = [ 3.0, 0.0 ]
@@ -50,7 +50,7 @@ def test_rychlikRainflowCounting_threePointsDecreasing_empty( mock_get ):
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-@patch( "ffpack.utils.generalUtils.getSequencePeakAndValleys" )
+@patch( "ffpack.utils.generalUtils.sequencePeakAndValleys" )
 def test_rychlikRainflowCounting_threePointsDownward_empty( mock_get ):
     # case 1: left is lower
     data = [ 1.0, 0.0, 2.0 ]
@@ -77,7 +77,7 @@ def test_rychlikRainflowCounting_threePointsDownward_empty( mock_get ):
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-@patch( "ffpack.utils.generalUtils.getSequencePeakAndValleys" )
+@patch( "ffpack.utils.generalUtils.sequencePeakAndValleys" )
 def test_rychlikRainflowCounting_threePointsUpward_smallerDistance( mock_get ):
     # case 1: right is higher
     data = [ 0.0, 2.0, 1.0 ]
@@ -104,7 +104,7 @@ def test_rychlikRainflowCounting_threePointsUpward_smallerDistance( mock_get ):
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-@patch( "ffpack.utils.generalUtils.getSequencePeakAndValleys" )
+@patch( "ffpack.utils.generalUtils.sequencePeakAndValleys" )
 def test_rychlikRainflowCounting_fourPointsNoCrossing_smallerDistance( mock_get ):
     # case 1: higher valley in the right
     data = [ 0.0, 3.0, 1.0, 2.0 ]
@@ -131,7 +131,7 @@ def test_rychlikRainflowCounting_fourPointsNoCrossing_smallerDistance( mock_get 
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-@patch( "ffpack.utils.generalUtils.getSequencePeakAndValleys" )
+@patch( "ffpack.utils.generalUtils.sequencePeakAndValleys" )
 def test_rychlikRainflowCounting_fivePoints_aggrated( mock_get ):
     data = [ 0.0, 3.0, 1.0, 4.0, 2.0 ]
     mock_get.return_value = [ 0.0, 3.0, 1.0, 4.0, 2.0 ]
@@ -145,7 +145,7 @@ def test_rychlikRainflowCounting_fivePoints_aggrated( mock_get ):
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-@patch( "ffpack.utils.generalUtils.getSequencePeakAndValleys" )
+@patch( "ffpack.utils.generalUtils.sequencePeakAndValleys" )
 def test_rychlikRainflowCounting_withRedundencePoints_aggrated( mock_get ):
     data = [ 0.0, 1.0, 3.0, 2.0, 1.0, 2.0, 3.0, 4.0, 3.0, 2.0 ]
     mock_get.return_value = [ 0.0, 3.0, 1.0, 4.0, 2.0 ]
@@ -159,7 +159,7 @@ def test_rychlikRainflowCounting_withRedundencePoints_aggrated( mock_get ):
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-@patch( "ffpack.utils.generalUtils.getSequencePeakAndValleys" )
+@patch( "ffpack.utils.generalUtils.sequencePeakAndValleys" )
 def test_rychlikRainflowCounting_withSamePeakPoints_oneKept( mock_get ):
     data = [ 0.0, 3.0, 3.0, 2.0, 1.0, 2.0, 3.0, 4.0, 4.0, 4.0, 2.0 ]
     mock_get.return_value = [ 0.0, 3.0, 1.0, 4.0, 2.0 ]
@@ -173,7 +173,7 @@ def test_rychlikRainflowCounting_withSamePeakPoints_oneKept( mock_get ):
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-@patch( "ffpack.utils.generalUtils.getSequencePeakAndValleys" )
+@patch( "ffpack.utils.generalUtils.sequencePeakAndValleys" )
 def test_rychlikRainflowCounting_normalUseCase_pass( mock_get ):
     # Standard level corssing counting data from E1049-85(2017) Fig.2(a)
     # No levels for this test case

--- a/tests/utils/test_utils_fdrUtils.py
+++ b/tests/utils/test_utils_fdrUtils.py
@@ -6,92 +6,92 @@ import pytest
 
 
 ###############################################################################
-# Test SnCurveFitter
+# Test FitterForSnCurve
 ###############################################################################
 def test_snCurverFitter_oneDimData_valueError():
     data = [ 1.0, 2.5, 3.0, 4.5 ]
     with pytest.raises( ValueError ):
-        _ = utils.SnCurveFitter( data, fatigueLimit=0.2 )
+        _ = utils.FitterForSnCurve( data, fatigueLimit=0.2 )
 
 
 def test_snCurverFitter_emptyData_valueError():
     data = [ [ ] ]
     with pytest.raises( ValueError ):
-        _ = utils.SnCurveFitter( data, fatigueLimit=0.2 )
+        _ = utils.FitterForSnCurve( data, fatigueLimit=0.2 )
 
     data = [ ]
     with pytest.raises( ValueError ):
-        _ = utils.SnCurveFitter( data, fatigueLimit=0.2 )
+        _ = utils.FitterForSnCurve( data, fatigueLimit=0.2 )
 
 
 def test_snCurverFitter_fatigueLimitLessZero_valueError():
     data = [ [ 10, 4 ], [ 10000, 1 ] ]
     with pytest.raises( ValueError ):
-        _ = utils.SnCurveFitter( data, fatigueLimit=0 )
+        _ = utils.FitterForSnCurve( data, fatigueLimit=0 )
 
     with pytest.raises( ValueError ):
-        _ = utils.SnCurveFitter( data, fatigueLimit=-1 )
+        _ = utils.FitterForSnCurve( data, fatigueLimit=-1 )
 
 
 def test_snCurverFitter_irregularData_valueError():
     data = [ [ 10, -4 ], [ -10000, 1 ] ]
     with pytest.raises( ValueError ):
-        _ = utils.SnCurveFitter( data, fatigueLimit=0.5 )
+        _ = utils.FitterForSnCurve( data, fatigueLimit=0.5 )
 
 
 def test_snCurverFitter_querySLessZero_valueError():
     data = [ [ 10, 4 ], [ 10000, 1 ] ]
     with pytest.raises( ValueError ):
-        snCurveFitter = utils.SnCurveFitter( data, fatigueLimit=0.5 )
-        _ = snCurveFitter.getN( 0 )
+        fitterForSnCurve = utils.FitterForSnCurve( data, fatigueLimit=0.5 )
+        _ = fitterForSnCurve.getN( 0 )
 
     with pytest.raises( ValueError ):
-        snCurveFitter = utils.SnCurveFitter( data, fatigueLimit=0.5 )
-        _ = snCurveFitter.getN( -1 )
+        fitterForSnCurve = utils.FitterForSnCurve( data, fatigueLimit=0.5 )
+        _ = fitterForSnCurve.getN( -1 )
 
 
 def test_snCurverFitter_twoPairsData_queryPass():
     data = [ [ 10, 4 ], [ 10000, 1 ] ]
-    snCurveFitter = utils.SnCurveFitter( data, fatigueLimit=0.5 )
-    np.testing.assert_allclose( snCurveFitter.getN( 4 ), 1e1 )
-    np.testing.assert_allclose( snCurveFitter.getN( 3 ), 1e2 )
-    np.testing.assert_allclose( snCurveFitter.getN( 2 ), 1e3 )
-    np.testing.assert_allclose( snCurveFitter.getN( 1 ), 1e4 )
-    np.testing.assert_allclose( snCurveFitter.getN( 0.5 ), -1 )
+    fitterForSnCurve = utils.FitterForSnCurve( data, fatigueLimit=0.5 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 4 ), 1e1 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 3 ), 1e2 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 2 ), 1e3 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 1 ), 1e4 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 0.5 ), -1 )
 
 
 def test_snCurverFitter_threePairsData_queryPass():
     data = [ [ 10, 5 ], [ 100, 4 ], [ 100000, 1 ] ]
-    snCurveFitter = utils.SnCurveFitter( data, fatigueLimit=0.2 )
-    np.testing.assert_allclose( snCurveFitter.getN( 5 ), 1e1 )
-    np.testing.assert_allclose( snCurveFitter.getN( 4 ), 1e2 )
-    np.testing.assert_allclose( snCurveFitter.getN( 3 ), 1e3 )
-    np.testing.assert_allclose( snCurveFitter.getN( 2 ), 1e4 )
-    np.testing.assert_allclose( snCurveFitter.getN( 1 ), 1e5 )
-    np.testing.assert_allclose( snCurveFitter.getN( 0.1 ), -1 )
+    fitterForSnCurve = utils.FitterForSnCurve( data, fatigueLimit=0.2 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 5 ), 1e1 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 4 ), 1e2 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 3 ), 1e3 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 2 ), 1e4 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 1 ), 1e5 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 0.1 ), -1 )
 
 
 def test_snCurverFitter_fourPairsData_queryPass():
     data = [ [ 10, 5.5 ], [ 10000, 4 ], [ 1000000, 3 ], [ 10000000, 2.5 ] ]
-    snCurveFitter = utils.SnCurveFitter( data, fatigueLimit=0.3 )
-    np.testing.assert_allclose( snCurveFitter.getN( 5 ), 1e2 )
-    np.testing.assert_allclose( snCurveFitter.getN( 4 ), 1e4 )
-    np.testing.assert_allclose( snCurveFitter.getN( 3 ), 1e6 )
-    np.testing.assert_allclose( snCurveFitter.getN( 2 ), 1e8 )
-    np.testing.assert_allclose( snCurveFitter.getN( 1 ), 1e10 )
-    np.testing.assert_allclose( snCurveFitter.getN( 0.3 ), -1 )
-    np.testing.assert_allclose( snCurveFitter.getN( 0.2 ), -1 )
-    np.testing.assert_allclose( snCurveFitter.getN( 0.1 ), -1 )
+    fitterForSnCurve = utils.FitterForSnCurve( data, fatigueLimit=0.3 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 5 ), 1e2 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 4 ), 1e4 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 3 ), 1e6 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 2 ), 1e8 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 1 ), 1e10 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 0.3 ), -1 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 0.2 ), -1 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 0.1 ), -1 )
 
 
 def test_snCurverFitter_fourPairsDataHighFatigueLimit_queryPass():
     data = [ [ 10, 5.5 ], [ 10000, 4 ], [ 1000000, 3 ], [ 10000000, 2.5 ] ]
-    snCurveFitter = utils.SnCurveFitter( data, fatigueLimit=2.5 )
-    np.testing.assert_allclose( snCurveFitter.getN( 5 ), 1e2 )
-    np.testing.assert_allclose( snCurveFitter.getN( 4 ), 1e4 )
-    np.testing.assert_allclose( snCurveFitter.getN( 3 ), 1e6 )
-    np.testing.assert_allclose( snCurveFitter.getN( 2 ), -1 )
-    np.testing.assert_allclose( snCurveFitter.getN( 1 ), -1 )
-    np.testing.assert_allclose( snCurveFitter.getN( 0.3 ), -1 )
-    np.testing.assert_allclose( snCurveFitter.getN( 0.2 ), -1 )
-    np.testing.assert_allclose( snCurveFitter.getN( 0.1 ), -1 )
+    fitterForSnCurve = utils.FitterForSnCurve( data, fatigueLimit=2.5 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 5 ), 1e2 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 4 ), 1e4 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 3 ), 1e6 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 2 ), -1 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 1 ), -1 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 0.3 ), -1 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 0.2 ), -1 )
+    np.testing.assert_allclose( fitterForSnCurve.getN( 0.1 ), -1 )

--- a/tests/utils/test_utils_generalUtils.py
+++ b/tests/utils/test_utils_generalUtils.py
@@ -6,209 +6,209 @@ import pytest
 
 
 ###############################################################################
-# Test getSequencePeakAndValleys
+# Test sequencePeakAndValleys
 ###############################################################################
-def test_getSequencePeakAndValleys_noPoints_valueError():
+def test_sequencePeakAndValleys_noPoints_valueError():
     data = [ ]
     with pytest.raises( ValueError ):
-        _ = utils.getSequencePeakAndValleys( data )
+        _ = utils.sequencePeakAndValleys( data )
     
     data = [ ]
     with pytest.raises( ValueError ):
-        _ = utils.getSequencePeakAndValleys( data, keepEnds=True )
+        _ = utils.sequencePeakAndValleys( data, keepEnds=True )
 
 
-def test_getSequencePeakAndValleys_twoDimData_valueError():
+def test_sequencePeakAndValleys_twoDimData_valueError():
     data = [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ]
     with pytest.raises( ValueError ):
-        _ = utils.getSequencePeakAndValleys( data )
+        _ = utils.sequencePeakAndValleys( data )
     
     data = [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ]
     with pytest.raises( ValueError ):
-        _ = utils.getSequencePeakAndValleys( data, keepEnds=True )
+        _ = utils.sequencePeakAndValleys( data, keepEnds=True )
 
 
-def test_getSequencePeakAndValleys_onePointsKeepEnds_valueError():
+def test_sequencePeakAndValleys_onePointsKeepEnds_valueError():
     data = [ 1.0 ]
     with pytest.raises( ValueError ):
-        _ = utils.getSequencePeakAndValleys( data )
+        _ = utils.sequencePeakAndValleys( data )
     
     data = [ 1.0 ]
     with pytest.raises( ValueError ):
-        _ = utils.getSequencePeakAndValleys( data, keepEnds=True )
+        _ = utils.sequencePeakAndValleys( data, keepEnds=True )
 
 
-def test_getSequencePeakAndValleys_twoPointsNotKeepEnds_valueError():
+def test_sequencePeakAndValleys_twoPointsNotKeepEnds_valueError():
     data = [ 1.0, 2.0 ]
     with pytest.raises( ValueError ):
-        _ = utils.getSequencePeakAndValleys( data )
+        _ = utils.sequencePeakAndValleys( data )
 
 
-def test_getSequencePeakAndValleys_twoPointsKeepEnds_pointskept():
+def test_sequencePeakAndValleys_twoPointsKeepEnds_pointskept():
     data = [ -0.5, 1.0 ]
     # Keep ends
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ -0.5, 1.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-def test_getSequencePeakAndValleys_threePointsSimple_pass():
+def test_sequencePeakAndValleys_threePointsSimple_pass():
     data = [ -0.5, 1.0, 0.0 ]
 
     # case 1: do not keep ends
-    calRst = utils.getSequencePeakAndValleys( data )
+    calRst = utils.sequencePeakAndValleys( data )
     expectedRst = [ 1.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 2: keep ends
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ -0.5, 1.0, 0.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-def test_getSequencePeakAndValleys_threePointsWithSameValue_depends():
+def test_sequencePeakAndValleys_threePointsWithSameValue_depends():
     # case 1: last two the same
     data = [ -0.5, 1.0, 1.0 ]
     
-    calRst = utils.getSequencePeakAndValleys( data )
+    calRst = utils.sequencePeakAndValleys( data )
     expectedRst = [  ]
     np.testing.assert_allclose( calRst, expectedRst )
 
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ -0.5, 1.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 2: first two the same
     data = [ 1.0, 1.0, 2.0 ]
     
-    calRst = utils.getSequencePeakAndValleys( data )
+    calRst = utils.sequencePeakAndValleys( data )
     expectedRst = [  ]
     np.testing.assert_allclose( calRst, expectedRst )
 
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ 1.0, 2.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 3: three values the same
     data = [ 1.0, 1.0, 1.0 ]
-    calRst = utils.getSequencePeakAndValleys( data )
+    calRst = utils.sequencePeakAndValleys( data )
     expectedRst = [  ]
     np.testing.assert_allclose( calRst, expectedRst )
 
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ 1.0, 1.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-def test_getSequencePeakAndValleys_fourPointsWithSameValue_depends():
+def test_sequencePeakAndValleys_fourPointsWithSameValue_depends():
     # case 1: last three the same
     data = [ -0.5, 1.0, 1.0, 1.0 ]
     
-    calRst = utils.getSequencePeakAndValleys( data )
+    calRst = utils.sequencePeakAndValleys( data )
     expectedRst = [  ]
     np.testing.assert_allclose( calRst, expectedRst )
 
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ -0.5, 1.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 2: first three the same
     data = [ 1.0, 1.0, 1.0, 2.0 ]
     
-    calRst = utils.getSequencePeakAndValleys( data )
+    calRst = utils.sequencePeakAndValleys( data )
     expectedRst = [  ]
     np.testing.assert_allclose( calRst, expectedRst )
 
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ 1.0, 2.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 3: first two the same, last two the same
     data = [ 1.0, 1.0, 2.0, 2.0 ]
     
-    calRst = utils.getSequencePeakAndValleys( data )
+    calRst = utils.sequencePeakAndValleys( data )
     expectedRst = [  ]
     np.testing.assert_allclose( calRst, expectedRst )
 
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ 1.0, 2.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-def test_getSequencePeakAndValleys_fivePointsWithSameValue_depends():
+def test_sequencePeakAndValleys_fivePointsWithSameValue_depends():
     # case 1: three in the middle the same
     data = [ -0.5, 1.0, 1.0, 1.0, 0.0 ]
     
-    calRst = utils.getSequencePeakAndValleys( data )
+    calRst = utils.sequencePeakAndValleys( data )
     expectedRst = [ 1.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ -0.5, 1.0, 0.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 2: last three the same
     data = [ -0.5, 1.0, 2.0, 2.0, 2.0 ]
     
-    calRst = utils.getSequencePeakAndValleys( data )
+    calRst = utils.sequencePeakAndValleys( data )
     expectedRst = [  ]
     np.testing.assert_allclose( calRst, expectedRst )
 
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ -0.5, 2.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-def test_getSequencePeakAndValleys_normalUseOnlyPeakAndValleys_pass():
+def test_sequencePeakAndValleys_normalUseOnlyPeakAndValleys_pass():
     data = [ -0.5, 1.0, -2.0, 3.0, -1.0, 4.5, -2.5, 3.5, -1.5, 1.0 ]
     # Do not keep ends
-    calRst = utils.getSequencePeakAndValleys( data )
+    calRst = utils.sequencePeakAndValleys( data )
     expectedRst = [ 1.0, -2.0, 3.0, -1.0, 4.5, -2.5, 3.5, -1.5 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ -0.5, 1.0, -2.0, 3.0, -1.0, 4.5, -2.5, 3.5, -1.5, 1.0 ]
     # Keep ends
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ -0.5, 1.0, -2.0, 3.0, -1.0, 4.5, -2.5, 3.5, -1.5, 1.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ 1.0, 2.0, 0.5, 3.0, 1.0, 4.5, 2.5, 3.5, 1.5, 4.0 ]
     # Do not keep ends
-    calRst = utils.getSequencePeakAndValleys( data )
+    calRst = utils.sequencePeakAndValleys( data )
     expectedRst = [ 2.0, 0.5, 3.0, 1.0, 4.5, 2.5, 3.5, 1.5 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ 1.0, 2.0, 0.5, 3.0, 1.0, 4.5, 2.5, 3.5, 1.5, 4.0 ]
     # Keep ends
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ 1.0, 2.0, 0.5, 3.0, 1.0, 4.5, 2.5, 3.5, 1.5, 4.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ -1.0, -2.0, -0.5, -3.0, -1.0, -4.5, -2.5, -3.5, -1.5, -4.0 ]
     # Do not keep ends
-    calRst = utils.getSequencePeakAndValleys( data )
+    calRst = utils.sequencePeakAndValleys( data )
     expectedRst = [ -2.0, -0.5, -3.0, -1.0, -4.5, -2.5, -3.5, -1.5 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ -1.0, -2.0, -0.5, -3.0, -1.0, -4.5, -2.5, -3.5, -1.5, -4.0 ]
     # Keep ends
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ -1.0, -2.0, -0.5, -3.0, -1.0, -4.5, -2.5, -3.5, -1.5, -4.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-def test_getSequencePeakAndValleys_normalUseExtraPointsInSequence_pass():
+def test_sequencePeakAndValleys_normalUseExtraPointsInSequence_pass():
     data = [ -0.5, 0.0, 1.0, -1.0, -2.0, -1.0, 1.5, 3.0, 2.5, -1.0, 0.5, 1.5, 4.5, 
              3.5, 1.0, -1.0, -2.5, -1.5, 3.0, 3.5, 1.5, 0.0, -1.5, 0.5, 1.0 ]
     # Do not keep ends
-    calRst = utils.getSequencePeakAndValleys( data )
+    calRst = utils.sequencePeakAndValleys( data )
     expectedRst = [ 1.0, -2.0, 3.0, -1.0, 4.5, -2.5, 3.5, -1.5 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ -0.5, 0.0, 1.0, -1.0, -2.0, -1.0, 1.5, 3.0, 2.5, -1.0, 0.5, 1.5, 4.5, 
              3.5, 1.0, -1.0, -2.5, -1.5, 3.0, 3.5, 1.5, 0.0, -1.5, 0.5, 1.0 ]
     # Keep ends
-    calRst = utils.getSequencePeakAndValleys( data, keepEnds=True )
+    calRst = utils.sequencePeakAndValleys( data, keepEnds=True )
     expectedRst = [ -0.5, 1.0, -2.0, 3.0, -1.0, 4.5, -2.5, 3.5, -1.5, 1.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
     
@@ -219,86 +219,86 @@ def test_getSequencePeakAndValleys_normalUseExtraPointsInSequence_pass():
 ###############################################################################
 def test_digitizeSequenceToResolution_normalUseCase_pass():
     data = [ 1.2, 2.6, 3.4, 0.8 ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=0.5 )
+    calRst = utils.sequenceDigitization( data, resolution=0.5 )
     expectedRst = [ 1.0, 2.5, 3.5, 1.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ -1.2, -2.6, -3.4, -0.8 ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=0.5 )
+    calRst = utils.sequenceDigitization( data, resolution=0.5 )
     expectedRst = [ -1.0, -2.5, -3.5, -1.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ -1.0, 2.3, 1.8, 0.6, -0.4, 0.8, -1.6, -2.5, 3.4, 0.3, 0.1 ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=0.1 )
+    calRst = utils.sequenceDigitization( data, resolution=0.1 )
     expectedRst = [ -1.0, 2.3, 1.8, 0.6, -0.4, 0.8, -1.6, -2.5, 3.4, 0.3, 0.1 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ -1.0, 2.3, 1.8, 0.6, -0.4, 0.8, -1.6, -2.5, 3.4, 0.3, 0.1 ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=0.5 )
+    calRst = utils.sequenceDigitization( data, resolution=0.5 )
     expectedRst = [ -1.0, 2.5, 2.0, 0.5, -0.5, 1.0, -1.5, -2.5, 3.5, 0.5, 0.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ -1.0, 2.3, 1.8, 0.6, -0.4, 0.8, -1.6, -2.5, 3.4, 0.3, 0.1 ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=1.0 )
+    calRst = utils.sequenceDigitization( data, resolution=1.0 )
     expectedRst = [ -1.0, 2.0, 2.0, 1.0, 0.0, 1.0, -2.0, -2.0, 3.0, 0.0, 0.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ -2.5, -1.5, -0.5, 0.5, 1.5, 2.5 ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=1.0 )
+    calRst = utils.sequenceDigitization( data, resolution=1.0 )
     expectedRst = [ -2.0, -2.0, 0.0, 0.0, 2.0, 2.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
 def test_digitizeSequenceToResolution_twoPointsCase_pass():
     data = [ np.pi, -np.pi ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=2.0 )
+    calRst = utils.sequenceDigitization( data, resolution=2.0 )
     expectedRst = [ 4.0, -4.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ np.pi, -np.pi ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=1.5 )
+    calRst = utils.sequenceDigitization( data, resolution=1.5 )
     expectedRst = [ 3.0, -3.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ np.pi, -np.pi ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=1.0 )
+    calRst = utils.sequenceDigitization( data, resolution=1.0 )
     expectedRst = [ 3.0, -3.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ np.pi, -np.pi ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=0.5 )
+    calRst = utils.sequenceDigitization( data, resolution=0.5 )
     expectedRst = [ 3.0, -3.0 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ np.pi, -np.pi ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=0.2 )
+    calRst = utils.sequenceDigitization( data, resolution=0.2 )
     expectedRst = [ 3.2, -3.2 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ np.pi, -np.pi ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=0.1 )
+    calRst = utils.sequenceDigitization( data, resolution=0.1 )
     expectedRst = [ 3.1, -3.1 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ np.pi, -np.pi ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=0.05 )
+    calRst = utils.sequenceDigitization( data, resolution=0.05 )
     expectedRst = [ 3.15, -3.15 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ np.pi, -np.pi ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=0.01 )
+    calRst = utils.sequenceDigitization( data, resolution=0.01 )
     expectedRst = [ 3.14, -3.14 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     data = [ np.pi, -np.pi ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=0.001 )
+    calRst = utils.sequenceDigitization( data, resolution=0.001 )
     expectedRst = [ 3.142, -3.142 ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
 def test_digitizeSequenceToResolution_emptyInputCase_pass():
     data = [ ]
-    calRst = utils.digitizeSequenceToResoultion( data, resolution=0.001 )
+    calRst = utils.sequenceDigitization( data, resolution=0.001 )
     expectedRst = [ ]
     np.testing.assert_allclose( calRst, expectedRst )
 
@@ -306,4 +306,4 @@ def test_digitizeSequenceToResolution_emptyInputCase_pass():
 def test_digitizeSequenceToResolution_twoDimInputCase_valueError():
     data = [ [ 1.0, 2.5 ], [ 3.0, 4.5 ] ]
     with pytest.raises( ValueError ):
-        _ = utils.digitizeSequenceToResoultion( data, resolution=1.0 )
+        _ = utils.sequenceDigitization( data, resolution=1.0 )

--- a/tests/utils/test_utils_lccUtils.py
+++ b/tests/utils/test_utils_lccUtils.py
@@ -5,89 +5,89 @@ import numpy as np
 
 
 ###############################################################################
-# Test cycleCountingAccordingToBinSize
+# Test cycleCountingAggregation
 ###############################################################################
-def test_cycleCountingAccordingToBinSize_onePairDefaultBinSize_oneCount():
+def test_cycleCountingAggregation_onePairDefaultBinSize_oneCount():
     # case 1: closer to 0
     data = [ [ 0.2, 2.0 ] ]
-    calRst = utils.cycleCountingAccordingToBinSize( data, binSize=1.0 )
+    calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
     expectedRst = [ [ 0.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 2: closer to 1
     data = [ [ 0.7, 2.0 ] ]
-    calRst = utils.cycleCountingAccordingToBinSize( data, binSize=1.0 )
+    calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
     expectedRst = [ [ 0.0, 0.0 ], [ 1.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 3: in the middle
     data = [ [ 0.5, 2.0 ] ]
-    calRst = utils.cycleCountingAccordingToBinSize( data, binSize=1.0 )
+    calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
     expectedRst = [ [ 0.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 4: greater than 1 and closer to 2
     data = [ [ 1.7, 2.0 ] ]
-    calRst = utils.cycleCountingAccordingToBinSize( data, binSize=1.0 )
+    calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
     expectedRst = [ [ 0.0, 0.0 ], [ 1.0, 0.0 ], [ 2.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 5: greater than 1 and closer to 1
     data = [ [ 1.2, 2.0 ] ]
-    calRst = utils.cycleCountingAccordingToBinSize( data, binSize=1.0 )
+    calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
     expectedRst = [ [ 0.0, 0.0 ], [ 1.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 6: greater than 1 and in the middle
     data = [ [ 1.5, 2.0 ] ]
-    calRst = utils.cycleCountingAccordingToBinSize( data, binSize=1.0 )
+    calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
     expectedRst = [ [ 0.0, 0.0 ], [ 1.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-def test_cycleCountingAccordingToBinSize_twoPairsDefaultBinSize_countDepends():
+def test_cycleCountingAggregation_twoPairsDefaultBinSize_countDepends():
     # case 1: aggregate to two bins
     data = [ [ 0.2, 2.0 ], [ 1.2, 2.0 ] ]
-    calRst = utils.cycleCountingAccordingToBinSize( data, binSize=1.0 )
+    calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
     expectedRst = [ [ 0.0, 2.0 ], [ 1.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 2: aggregate to one bin
     data = [ [ 0.7, 2.0 ], [ 1.2, 2.0 ] ]
-    calRst = utils.cycleCountingAccordingToBinSize( data, binSize=1.0 )
+    calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
     expectedRst = [ [ 0.0, 0.0 ], [ 1.0, 4.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 3: aggregate to one bin - lager than binSize
     data = [ [ 1.7, 2.0 ], [ 2.2, 2.0 ] ]
-    calRst = utils.cycleCountingAccordingToBinSize( data, binSize=1.0 )
+    calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
     expectedRst = [ [ 0.0, 0.0 ], [ 1.0, 0.0 ], [ 2.0, 4.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-def test_cycleCountingAccordingToBinSize_twoPairsSmallerBinSize_countDepends():
+def test_cycleCountingAggregation_twoPairsSmallerBinSize_countDepends():
     # case 1: aggregate to two bins
     data = [ [ 0.3, 2.0 ], [ 0.9, 2.0 ] ]
-    calRst = utils.cycleCountingAccordingToBinSize( data, binSize=0.5 )
+    calRst = utils.cycleCountingAggregation( data, binSize=0.5 )
     expectedRst = [ [ 0.0, 0.0 ], [ 0.5, 2.0 ], [ 1.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 2: aggregate to one bin
     data = [ [ 0.3, 2.0 ], [ 0.7, 2.0 ] ]
-    calRst = utils.cycleCountingAccordingToBinSize( data, binSize=0.5 )
+    calRst = utils.cycleCountingAggregation( data, binSize=0.5 )
     expectedRst = [ [ 0.0, 0.0 ], [ 0.5, 4.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
-def test_cycleCountingAccordingToBinSize_twoPairsLargerBinSize_countDepends():
+def test_cycleCountingAggregation_twoPairsLargerBinSize_countDepends():
     # case 1: aggregate to two bins
     data = [ [ 0.3, 2.0 ], [ 2.9, 2.0 ] ]
-    calRst = utils.cycleCountingAccordingToBinSize( data, binSize=2.0 )
+    calRst = utils.cycleCountingAggregation( data, binSize=2.0 )
     expectedRst = [ [ 0.0, 2.0 ], [ 2.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 2: aggregate to one bin
     data = [ [ 1.8, 2.0 ], [ 2.7, 2.0 ] ]
-    calRst = utils.cycleCountingAccordingToBinSize( data, binSize=2.0 )
+    calRst = utils.cycleCountingAggregation( data, binSize=2.0 )
     expectedRst = [ [ 0.0, 0.0 ], [ 2.0, 4.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )


### PR DESCRIPTION
Updated function name in utils module.

Here is the name convention in FFPACK:
we treat `=` as `is`. 

For example:
when we define `result = sequencePeakAndValleys( ... )`. This means `result is sequencePeakAndValleys( ... )`.
Thus, we do **NOT** use `result = getSequencePeakAndValleys( ... )`.

We only use getter and setter in class functions.