### PR TITLE
utils/cycleCountingAggregation 

### DIFF
--- a/src/ffpack/utils/lccUtils.py
+++ b/src/ffpack/utils/lccUtils.py
@@ -19,16 +19,14 @@ def cycleCountingAggregation( data, binSize=1.0 ):
     Returns
     -------
     rst: 2d array
-        Aggregated [ [ range, count ] ] with range starts from 0 to maximum 
-        possible value by the binSize
+        Aggregated [ [ range, count ] ] by the binSize
 
 
     Raises
     ------
     ValueError
-        If the data dimension is not 1.
-        If the data length is less than 2 with keedEnds == False
-        If the data length is less than 3 with keedEnds == True
+        If the data dimension is not 2.
+        If the data is empty
 
     Notes
     -----
@@ -41,6 +39,13 @@ def cycleCountingAggregation( data, binSize=1.0 ):
     >>> data = [ [ 1.7, 2.0 ], [ 2.2, 2.0 ] ]
     >>> rst = cycleCountingAggregation( data )
     '''
+    # Egde cases
+    data = np.array( data )
+    if len( data.shape ) != 2:
+        raise ValueError( "Input data dimension should be 2" )
+    if data.shape[1] != 2:
+        raise ValueError( "Input data length should be at least 1")
+
     def getBinKey( value ):
         key = binSize * int( value / binSize )
         if ( value - key > key + binSize - value):
@@ -48,11 +53,6 @@ def cycleCountingAggregation( data, binSize=1.0 ):
         return key
 
     rstDict = defaultdict( int )
-    max_value = np.max( np.array( data )[ :, 0 ] )
-    numBins = int( getBinKey( max_value ) / binSize ) + 1
-    for i in range( numBins ):
-        rstDict[ i * binSize ] = 0
-
     for valueCount in data:
         key = getBinKey( valueCount[ 0 ] )
         rstDict[ key ] += valueCount[ 1 ]

--- a/src/ffpack/utils/lccUtils.py
+++ b/src/ffpack/utils/lccUtils.py
@@ -44,7 +44,7 @@ def cycleCountingAggregation( data, binSize=1.0 ):
     if len( data.shape ) != 2:
         raise ValueError( "Input data dimension should be 2" )
     if data.shape[1] != 2:
-        raise ValueError( "Input data length should be at least 1")
+        raise ValueError( "Input data should be [ value, count ] pairs")
 
     def getBinKey( value ):
         key = binSize * int( value / binSize )

--- a/src/ffpack/utils/lccUtils.py
+++ b/src/ffpack/utils/lccUtils.py
@@ -10,7 +10,7 @@ def cycleCountingAggregation( data, binSize=1.0 ):
     Parameters
     ----------
     data: 2d array
-        Input load cycle counting data [ [ range, count ], ... ] for bin collection 
+        Input load cycle counting data [ [ value, count ], ... ] for bin collection 
 
     binSize: scalar, optional
         bin size is the difference between each level, 
@@ -19,7 +19,7 @@ def cycleCountingAggregation( data, binSize=1.0 ):
     Returns
     -------
     rst: 2d array
-        Aggregated [ [ range, count ] ] by the binSize
+        Aggregated [ [ aggregatedValue, count ] ] by the binSize
 
 
     Raises

--- a/tests/utils/test_utils_lccUtils.py
+++ b/tests/utils/test_utils_lccUtils.py
@@ -2,11 +2,32 @@
 
 from ffpack import utils
 import numpy as np
+import pytest
 
 
 ###############################################################################
 # Test cycleCountingAggregation
 ###############################################################################
+def test_cycleCountingAggregation_emptyData_valueError():
+    data = [ [ ] ]
+    with pytest.raises( ValueError ):
+        _ = utils.cycleCountingAggregation( data )
+
+
+def test_cycleCountingAggregation_incorrectDataDim_valueError():
+    data = [  ]
+    with pytest.raises( ValueError ):
+        _ = utils.cycleCountingAggregation( data )
+    
+    data = [ [ 1.0 ] ]
+    with pytest.raises( ValueError ):
+        _ = utils.cycleCountingAggregation( data )
+    
+    data = [ [ 1.0, 2.0, 3.0 ] ]
+    with pytest.raises( ValueError ):
+        _ = utils.cycleCountingAggregation( data )
+
+
 def test_cycleCountingAggregation_onePairDefaultBinSize_oneCount():
     # case 1: closer to 0
     data = [ [ 0.2, 2.0 ] ]
@@ -17,7 +38,7 @@ def test_cycleCountingAggregation_onePairDefaultBinSize_oneCount():
     # case 2: closer to 1
     data = [ [ 0.7, 2.0 ] ]
     calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
-    expectedRst = [ [ 0.0, 0.0 ], [ 1.0, 2.0 ] ]
+    expectedRst = [ [ 1.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 3: in the middle
@@ -29,19 +50,19 @@ def test_cycleCountingAggregation_onePairDefaultBinSize_oneCount():
     # case 4: greater than 1 and closer to 2
     data = [ [ 1.7, 2.0 ] ]
     calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
-    expectedRst = [ [ 0.0, 0.0 ], [ 1.0, 0.0 ], [ 2.0, 2.0 ] ]
+    expectedRst = [ [ 2.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 5: greater than 1 and closer to 1
     data = [ [ 1.2, 2.0 ] ]
     calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
-    expectedRst = [ [ 0.0, 0.0 ], [ 1.0, 2.0 ] ]
+    expectedRst = [ [ 1.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 6: greater than 1 and in the middle
     data = [ [ 1.5, 2.0 ] ]
     calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
-    expectedRst = [ [ 0.0, 0.0 ], [ 1.0, 2.0 ] ]
+    expectedRst = [ [ 1.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
@@ -55,13 +76,13 @@ def test_cycleCountingAggregation_twoPairsDefaultBinSize_countDepends():
     # case 2: aggregate to one bin
     data = [ [ 0.7, 2.0 ], [ 1.2, 2.0 ] ]
     calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
-    expectedRst = [ [ 0.0, 0.0 ], [ 1.0, 4.0 ] ]
+    expectedRst = [ [ 1.0, 4.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 3: aggregate to one bin - lager than binSize
     data = [ [ 1.7, 2.0 ], [ 2.2, 2.0 ] ]
     calRst = utils.cycleCountingAggregation( data, binSize=1.0 )
-    expectedRst = [ [ 0.0, 0.0 ], [ 1.0, 0.0 ], [ 2.0, 4.0 ] ]
+    expectedRst = [ [ 2.0, 4.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
@@ -69,13 +90,13 @@ def test_cycleCountingAggregation_twoPairsSmallerBinSize_countDepends():
     # case 1: aggregate to two bins
     data = [ [ 0.3, 2.0 ], [ 0.9, 2.0 ] ]
     calRst = utils.cycleCountingAggregation( data, binSize=0.5 )
-    expectedRst = [ [ 0.0, 0.0 ], [ 0.5, 2.0 ], [ 1.0, 2.0 ] ]
+    expectedRst = [ [ 0.5, 2.0 ], [ 1.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     # case 2: aggregate to one bin
     data = [ [ 0.3, 2.0 ], [ 0.7, 2.0 ] ]
     calRst = utils.cycleCountingAggregation( data, binSize=0.5 )
-    expectedRst = [ [ 0.0, 0.0 ], [ 0.5, 4.0 ] ]
+    expectedRst = [ [ 0.5, 4.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
 
@@ -89,5 +110,5 @@ def test_cycleCountingAggregation_twoPairsLargerBinSize_countDepends():
     # case 2: aggregate to one bin
     data = [ [ 1.8, 2.0 ], [ 2.7, 2.0 ] ]
     calRst = utils.cycleCountingAggregation( data, binSize=2.0 )
-    expectedRst = [ [ 0.0, 0.0 ], [ 2.0, 4.0 ] ]
+    expectedRst = [ [ 2.0, 4.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )

--- a/tests/utils/test_utils_lccUtils.py
+++ b/tests/utils/test_utils_lccUtils.py
@@ -8,13 +8,11 @@ import pytest
 ###############################################################################
 # Test cycleCountingAggregation
 ###############################################################################
-def test_cycleCountingAggregation_emptyData_valueError():
+def test_cycleCountingAggregation_incorrectData_valueError():
     data = [ [ ] ]
     with pytest.raises( ValueError ):
         _ = utils.cycleCountingAggregation( data )
-
-
-def test_cycleCountingAggregation_incorrectDataDim_valueError():
+    
     data = [  ]
     with pytest.raises( ValueError ):
         _ = utils.cycleCountingAggregation( data )


### PR DESCRIPTION
cycleCountingAggregation should not output 0 counts

For the rainflow counting results, we can get the results:
`[ [ 1.7, 1.0 ], [ 2.2, 2.0 ], [ 3.6, 3.0 ],[ 4.1, 1.0 ] ]`
The result is in form of [ [ value, counts ], ... ].

After we call the function cycleCountingAggregation, the results should be aggregated by the binSize. For the above example, if we select the binSize==1, then the output should be:
`[ [ 2.0, 3.0 ], [ 4.0, 4.0 ] ]`
The result is in form of [ [ aggregatedValue, counts ], ... ].