### PR TITLE
Lcc/countdetail

### DIFF
--- a/src/ffpack/lcc/rychlikCounting.py
+++ b/src/ffpack/lcc/rychlikCounting.py
@@ -75,15 +75,16 @@ def rychlikRainflowCounting( data, aggregate=True ):
     for i in range( 1, len( data ) - 1 ):
         if ( data[ i ] > data[ i - 1 ] and data[ i ] > data[ i + 1 ] ):
             # TODO: set a global variable for round digit
-            height = data[ i ] - max( getMinLeft( data, i ), getMinRight( data, i ))
-            rstSeq.append( round( height, 7 ) )
+            higher = max( getMinLeft( data, i ), getMinRight( data, i ))
+            rstSeq.append( [ higher, data[ i ] ] )
     
     if ( not aggregate ): 
         return rstSeq
 
     rstDict = defaultdict( int )
-    for i, cur in enumerate( rstSeq ):
-        rstDict[ cur ] += 1
+    for lowHigh in rstSeq:
+        height = round( lowHigh[ 1 ] - lowHigh[ 0 ], 7 )
+        rstDict[ height ] += 1
 
     if len( rstDict ) == 0:
         return [ [ ] ] 

--- a/src/ffpack/lcc/rychlikCounting.py
+++ b/src/ffpack/lcc/rychlikCounting.py
@@ -30,7 +30,13 @@ def rychlikRainflowCounting( data, aggregate=True ):
     -------
     rst: 2d array
         Sorted counting restults.
-    
+
+    Raises
+    ------
+    ValueError
+        If the data dimension is not 1
+        If the data length is less than 2
+
     Notes
     -----
     If aggregate is False, the original 1d counting results will be returned.
@@ -42,7 +48,13 @@ def rychlikRainflowCounting( data, aggregate=True ):
     >>>          -2.2, -2.6, -2.4, -3.3, 1.5, 0.6, 3.4, -0.5 ]
     >>> rst = rychlikRainflowCycleCounting( data )
     '''
-
+    # Egde cases
+    data = np.array( data )
+    if len( data.shape ) != 1:
+        raise ValueError( "Input data dimension should be 1" )
+    if data.shape[0] < 2:
+        raise ValueError( "Input data length should be at least 2")
+    
     def getMinLeft( data, i ):
         if ( i == 1 ): 
             return min( data[ 0 ], data[ 1 ] )

--- a/src/ffpack/lcc/rychlikCounting.py
+++ b/src/ffpack/lcc/rychlikCounting.py
@@ -24,12 +24,13 @@ def rychlikRainflowCounting( data, aggregate=True ):
     data: 1d array 
         Load sequence data for counting.
     aggragate: bool, optional
-        if aggregate set to False, the original range H(t) sequence will be returned.
+        if aggregate set to False, the original sequence will be returned.
     
     Returns
     -------
     rst: 2d array
-        Sorted counting restults.
+        Array of sequence [ start or end , peak ] for range H(t) if not aggregate.
+        Sorted counting results if aggregate (default).
 
     Raises
     ------
@@ -53,7 +54,7 @@ def rychlikRainflowCounting( data, aggregate=True ):
     if len( data.shape ) != 1:
         raise ValueError( "Input data dimension should be 1" )
     if data.shape[0] < 2:
-        raise ValueError( "Input data length should be at least 2")
+        raise ValueError( "Input data length should be at least 2" )
     
     def getMinLeft( data, i ):
         if ( i == 1 ): 
@@ -87,7 +88,7 @@ def rychlikRainflowCounting( data, aggregate=True ):
     for i in range( 1, len( data ) - 1 ):
         if ( data[ i ] > data[ i - 1 ] and data[ i ] > data[ i + 1 ] ):
             # TODO: set a global variable for round digit
-            higher = max( getMinLeft( data, i ), getMinRight( data, i ))
+            higher = max( getMinLeft( data, i ), getMinRight( data, i ) )
             rstSeq.append( [ higher, data[ i ] ] )
     
     if ( not aggregate ): 

--- a/tests/lcc/test_lcc_rychlikCounting.py
+++ b/tests/lcc/test_lcc_rychlikCounting.py
@@ -2,12 +2,45 @@
 
 from ffpack import lcc
 import numpy as np
+import pytest
 from unittest.mock import patch
 
 
 ###############################################################################
 # Test rychlikRainflowCounting function
 ###############################################################################
+def test_srychlikRainflowCounting_noPointsOrOnePoint_valueError():
+    data = [ ]
+    with pytest.raises( ValueError ):
+        _ = lcc.rychlikRainflowCounting( data, False )
+    
+    with pytest.raises( ValueError ):
+        _ = lcc.rychlikRainflowCounting( data, True )
+
+    data = [ 1.0 ]
+    with pytest.raises( ValueError ):
+        _ = lcc.rychlikRainflowCounting( data, False )
+    
+    with pytest.raises( ValueError ):
+        _ = lcc.rychlikRainflowCounting( data, True )
+
+
+def test_srychlikRainflowCounting_incorrectDataDim_valueError():
+    data = [ [ 1.0 ] ]
+    with pytest.raises( ValueError ):
+        _ = lcc.rychlikRainflowCounting( data, False )
+    
+    with pytest.raises( ValueError ):
+        _ = lcc.rychlikRainflowCounting( data, True )
+
+    data = [ [ [ 1.0 ] ] ]
+    with pytest.raises( ValueError ):
+        _ = lcc.rychlikRainflowCounting( data, False )
+    
+    with pytest.raises( ValueError ):
+        _ = lcc.rychlikRainflowCounting( data, True )
+
+
 @patch( "ffpack.utils.generalUtils.sequencePeakAndValleys" )
 def test_rychlikRainflowCounting_twoPoints_empty( mock_get ):
     data = [ 0.0, 2.0 ]

--- a/tests/lcc/test_lcc_rychlikCounting.py
+++ b/tests/lcc/test_lcc_rychlikCounting.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 ###############################################################################
 # Test rychlikRainflowCounting function
 ###############################################################################
-def test_srychlikRainflowCounting_noPointsOrOnePoint_valueError():
+def test_rychlikRainflowCounting_noPointsOrOnePoint_valueError():
     data = [ ]
     with pytest.raises( ValueError ):
         _ = lcc.rychlikRainflowCounting( data, False )
@@ -25,7 +25,7 @@ def test_srychlikRainflowCounting_noPointsOrOnePoint_valueError():
         _ = lcc.rychlikRainflowCounting( data, True )
 
 
-def test_srychlikRainflowCounting_incorrectDataDim_valueError():
+def test_rychlikRainflowCounting_incorrectDataDim_valueError():
     data = [ [ 1.0 ] ]
     with pytest.raises( ValueError ):
         _ = lcc.rychlikRainflowCounting( data, False )

--- a/tests/lcc/test_lcc_rychlikCounting.py
+++ b/tests/lcc/test_lcc_rychlikCounting.py
@@ -84,7 +84,7 @@ def test_rychlikRainflowCounting_threePointsUpward_smallerDistance( mock_get ):
     mock_get.return_value = [ 0.0, 2.0, 1.0 ]
 
     calRst = lcc.rychlikRainflowCounting( data, False )
-    expectedRst = [ 1.0 ]
+    expectedRst = [ [ 1.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     calRst = lcc.rychlikRainflowCounting( data, True )
@@ -96,7 +96,7 @@ def test_rychlikRainflowCounting_threePointsUpward_smallerDistance( mock_get ):
     mock_get.return_value = [ 1.0, 2.0, 0.0 ]
 
     calRst = lcc.rychlikRainflowCounting( data, False )
-    expectedRst = [ 1.0 ]
+    expectedRst = [ [ 1.0, 2.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     calRst = lcc.rychlikRainflowCounting( data, True )
@@ -111,7 +111,7 @@ def test_rychlikRainflowCounting_fourPointsNoCrossing_smallerDistance( mock_get 
     mock_get.return_value = [ 0.0, 3.0, 1.0, 2.0 ]
     
     calRst = lcc.rychlikRainflowCounting( data, False )
-    expectedRst = [ 2.0 ]
+    expectedRst = [ [ 1.0, 3.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     calRst = lcc.rychlikRainflowCounting( data, True )
@@ -123,7 +123,7 @@ def test_rychlikRainflowCounting_fourPointsNoCrossing_smallerDistance( mock_get 
     mock_get.return_value = [ 1.0, 3.0, 0.0, 2.0 ]
 
     calRst = lcc.rychlikRainflowCounting( data, False )
-    expectedRst = [ 2.0 ]
+    expectedRst = [ [ 1.0, 3.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     calRst = lcc.rychlikRainflowCounting( data, True )
@@ -137,7 +137,7 @@ def test_rychlikRainflowCounting_fivePoints_aggrated( mock_get ):
     mock_get.return_value = [ 0.0, 3.0, 1.0, 4.0, 2.0 ]
 
     calRst = lcc.rychlikRainflowCounting( data, False )
-    expectedRst = [ 2.0, 2.0 ]
+    expectedRst = [ [ 1.0, 3.0 ], [ 2.0, 4.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     calRst = lcc.rychlikRainflowCounting( data, True )
@@ -151,7 +151,7 @@ def test_rychlikRainflowCounting_withRedundencePoints_aggrated( mock_get ):
     mock_get.return_value = [ 0.0, 3.0, 1.0, 4.0, 2.0 ]
 
     calRst = lcc.rychlikRainflowCounting( data, False )
-    expectedRst = [ 2.0, 2.0 ]
+    expectedRst = [ [ 1.0, 3.0 ], [ 2.0, 4.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     calRst = lcc.rychlikRainflowCounting( data, True )
@@ -165,7 +165,7 @@ def test_rychlikRainflowCounting_withSamePeakPoints_oneKept( mock_get ):
     mock_get.return_value = [ 0.0, 3.0, 1.0, 4.0, 2.0 ]
 
     calRst = lcc.rychlikRainflowCounting( data, False )
-    expectedRst = [ 2.0, 2.0 ]
+    expectedRst = [ [ 1.0, 3.0 ], [ 2.0, 4.0 ] ]
     np.testing.assert_allclose( calRst, expectedRst )
 
     calRst = lcc.rychlikRainflowCounting( data, True )
@@ -183,8 +183,8 @@ def test_rychlikRainflowCounting_normalUseCase_pass( mock_get ):
                               -2.2, -2.6, -2.4, -3.3, 1.5, 0.6, 3.4, -0.5 ]
 
     calRst = lcc.rychlikRainflowCounting( data, False )
-    expectedRst = [ 1.3 - 0.7, 3.4 + 0.8, 2.5 - 0.7, -0.5 + 1.4, 
-                    -2.2 + 2.3, -2.4 + 2.6, 1.5 - 0.6, 3.4 + 0.5] 
+    expectedRst = [ [ 0.7, 1.3 ], [ -0.8, 3.4 ], [ 0.7, 2.5 ], [ -1.4, -0.5 ], 
+                    [ -2.3, -2.2 ], [ -2.6, -2.4 ], [ 0.6, 1.5 ], [ -0.5, 3.4 ] ] 
     np.testing.assert_allclose( calRst, expectedRst )
 
     calRst = lcc.rychlikRainflowCounting( data, True )
@@ -199,8 +199,8 @@ def test_rychlikRainflowCounting_normalUseCase_pass( mock_get ):
              -2.0, -1.0, 0.0, 1.0, 1.5, 0.6, 1.0, 2.0, 3.0, 3.4, 
              3.0, 2.0, 1.0, 0.0, -0.5 ]
     calRst = lcc.rychlikRainflowCounting( data, False )
-    expectedRst = [ 1.3 - 0.7, 3.4 + 0.8, 2.5 - 0.7, -0.5 + 1.4, 
-                    -2.2 + 2.3, -2.4 + 2.6, 1.5 - 0.6, 3.4 + 0.5 ]
+    expectedRst = [ [ 0.7, 1.3 ], [ -0.8, 3.4 ], [ 0.7, 2.5 ], [ -1.4, -0.5 ], 
+                    [ -2.3, -2.2 ], [ -2.6, -2.4 ], [ 0.6, 1.5 ], [ -0.5, 3.4 ] ] 
     np.testing.assert_allclose( calRst, expectedRst )
 
     calRst = lcc.rychlikRainflowCounting( data, True )
@@ -218,8 +218,8 @@ def test_rychlikRainflowCounting_normalUseCase_pass( mock_get ):
                               -2.2, -2.6, -2.4, -3.3, 1.5, 0.7, 3.4, -0.5 ]
     
     calRst = lcc.rychlikRainflowCounting( data, False )
-    expectedRst = [ 1.3 - 0.7, 3.4 + 0.8, 2.5 - 0.7, -0.5 + 1.4, 
-                    -2.2 + 2.3, -2.4 + 2.6, 1.5 - 0.7, 3.4 + 0.5 ]
+    expectedRst = [ [ 0.7, 1.3 ], [ -0.8, 3.4 ], [ 0.7, 2.5 ], [ -1.4, -0.5 ], 
+                    [ -2.3, -2.2 ], [ -2.6, -2.4 ], [ 0.7, 1.5 ], [ -0.5, 3.4 ] ] 
     np.testing.assert_allclose( calRst, expectedRst )
 
     calRst = lcc.rychlikRainflowCounting( data, True )


### PR DESCRIPTION
lcc module `rychlikRainflowCounting`
- modified return results: sorted counting results if aggregate, sequence of [ start or end, peak ] if not aggregate
- added input data check