### PR TITLE
docs/updated lcc module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![DOI](https://zenodo.org/badge/575208693.svg)](https://zenodo.org/badge/latestdoi/575208693)
 
 ## Purpose
-`FFPACK` ( Fatigue and Fracture PACKage ) is an open-source Python library for fatigue and fracture analysis. It supports load cycle counting with ASTM methods, load sequence generators, fatigue damage evaluations, etc. A lot of features are under active development. `FFPACK` is designed to help engineers analyze fatigue and fracture behavior in engineering practice.
+`FFPACK` ( Fatigue and Fracture PACKage ) is an open-source Python library for fatigue and fracture analysis. It supports cycle counting with ASTM methods, load sequence generators, fatigue damage evaluations, etc. A lot of features are under active development. `FFPACK` is designed to help engineers analyze fatigue and fracture behavior in engineering practice.
 
 ## Installation
 
@@ -26,7 +26,7 @@ pip install ffpack
         * Naive Palmgren-miner damage rule
         * Classic Palmgren-miner damage rule
 
-* Load cycle counting
+* Load correction and counting
     * ASTM counting
         * ASTM level crossing counting
         * ASTM peak counting

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,8 +8,8 @@ Module API
 
    module/fdr
 
-``lcc`` load cycle counting 
----------------------------
+``lcc`` load correction and counting 
+------------------------------------
 .. toctree::
    :maxdepth: 2
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,7 +49,7 @@ Contents
    :caption: Cookbook:
 
    fatigue damage rule
-   load cycle counting
+   load correction and counting
    load sequence generator
    load spectra and matrices
    random and probabilistic model

--- a/docs/source/load correction and counting.ipynb
+++ b/docs/source/load correction and counting.ipynb
@@ -5,7 +5,7 @@
    "id": "579711aa",
    "metadata": {},
    "source": [
-    "# Load cycle counting ( lcc )"
+    "# Load correction and counting ( lcc )"
    ]
   },
   {
@@ -13,7 +13,7 @@
    "id": "74ed8968",
    "metadata": {},
    "source": [
-    "Load cycle counting module provides several cycle counting methods."
+    "Load correction and counting module provides several load correction and cycle counting methods."
    ]
   },
   {

--- a/docs/source/utility methods.ipynb
+++ b/docs/source/utility methods.ipynb
@@ -279,7 +279,7 @@
       "    Parameters\n",
       "    ----------\n",
       "    data: 2d array\n",
-      "        Input load cycle counting data [ [ value, count ], ... ] for bin collection \n",
+      "        Input cycle counting data [ [ value, count ], ... ] for bin collection \n",
       "    \n",
       "    binSize: scalar, optional\n",
       "        bin size is the difference between each level, \n",

--- a/src/ffpack/utils/lccUtils.py
+++ b/src/ffpack/utils/lccUtils.py
@@ -10,7 +10,7 @@ def cycleCountingAggregation( data, binSize=1.0 ):
     Parameters
     ----------
     data: 2d array
-        Input load cycle counting data [ [ value, count ], ... ] for bin collection 
+        Input cycle counting data [ [ value, count ], ... ] for bin collection 
 
     binSize: scalar, optional
         bin size is the difference between each level, 


### PR DESCRIPTION
Updated `lcc` module name.

It is still called `lcc` module. Now it refers the `load correction and counting` instead of `load cycle counting`.