### PR TITLE
docs/downgraded docutils version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 myst_parser
 ipykernel
 nbsphinx
-docutils<0.18
+docutils<0.17

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 myst_parser
 ipykernel
 nbsphinx
+docutils<0.18

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,8 +9,8 @@ project = 'FFPACK'
 copyright = '2022, Dongping Zhu'
 author = 'Dongping Zhu'
 
-release = '0.1.0'
-version = '0.1.0'
+release = '0.3.0'
+version = '0.3.0'
 
 # -- General configuration
 
@@ -26,7 +26,7 @@ extensions = [
     'nbsphinx',
 ]
 
-source_suffix = [".rst", ".md"]
+source_suffix = ['.rst', '.md']
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
@@ -41,7 +41,7 @@ templates_path = ['_templates']
 html_theme = 'sphinx_rtd_theme'
 
 # -- Options for EPUB output
-epub_show_urls = 'footnote'
+epub_show_urls = "footnote"
 
 def skip(app, what, name, obj, would_skip, options):
     if name == "__init__":

--- a/docs/source/module/rpm.rst
+++ b/docs/source/module/rpm.rst
@@ -7,5 +7,5 @@ Metropolis Hastings algorithm
 Nataf transformation
 -----------------------------
 
-.. automodule:: ffpack.rpm.natafTransformation
+.. automodule:: ffpack.rpm.nataf
    :members:

--- a/docs/source/module/rrm.rst
+++ b/docs/source/module/rrm.rst
@@ -3,3 +3,9 @@ First order second moment
 
 .. automodule:: ffpack.rrm.firstOrderSecondMoment
    :members:
+
+First order reliability method
+------------------------------
+
+.. automodule:: ffpack.rrm.firstOrderReliabilityMethod
+   :members:

--- a/docs/source/readme.md
+++ b/docs/source/readme.md
@@ -1,0 +1,2 @@
+```{include} ../../README.md
+```

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -1,2 +1,0 @@
-.. include:: ../../README.md
-   :parser: myst_parser.sphinx_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ffpack"
-version = "0.2.0"
+version = "0.3.0"
 description = "Fatigue and fracture package"
 authors = [
     "Dongping Zhu",

--- a/src/ffpack/rrm/firstOrderReliabilityMethod.py
+++ b/src/ffpack/rrm/firstOrderReliabilityMethod.py
@@ -60,11 +60,11 @@ def form( dim, g, dg, distObjs, corrMat, iter=1000, tol=1e-6 ):
     --------
     >>> from ffpack.rrm import form
     >>> dim = 2
-    >>> g = lambda X: 3 * X[ 0 ] - 2 * X[ 1 ]
-    >>> dg = [ lambda X: 3, lambda X: -2 ]
-    >>> mus = [ 1, 1 ]
-    >>> sigmas = [ 3, 4 ]
-    >>> beta, pf = fosm( dim, g, dg, mus, sigmas)
+    >>> g = lambda X: -np.sum( X ) + 1
+    >>> dg = [ lambda X: -1, lambda X: -1 ]
+    >>> distObjs = [ sp.stats.norm(), sp.stats.norm() ]
+    >>> corrMat = np.eye( dim )
+    >>> beta, pf, uCoord, xCoord = rrm.form( dim, g, dg, distObjs, corrMat )
     '''
     if dim < 1:
         raise ValueError( "dim cannot be less than 1" )


### PR DESCRIPTION
Use the new version of docutils causing the rendering problem for bullet list on readthedocs.
Currently, downgrading the docutils to 0.16 can solve the problem. 

Here are some details:

- [Readthedocs / Sphinx not rendering bullet list from rst file](https://stackoverflow.com/questions/67542699/readthedocs-sphinx-not-rendering-bullet-list-from-rst-file)
- [rendering wrong in docutils 0.17](https://github.com/readthedocs/sphinx_rtd_theme/issues/1115)