### PR TITLE
rrm/ use scipy module instead of sp

### DIFF
--- a/src/ffpack/rpm/nataf.py
+++ b/src/ffpack/rpm/nataf.py
@@ -24,7 +24,7 @@ in reference [2]_.
 '''
 
 import numpy as np
-import scipy as sp
+from scipy import stats, optimize
 
 class NatafTransformation:
     '''
@@ -113,9 +113,9 @@ class NatafTransformation:
                         ( x**2 - 2 * rho * x * y + y**2 ) )
         
         def solve( func, x0 ):
-            rst = sp.optimize.fsolve( func=func, 
-                                      x0=x0,
-                                      full_output=True )
+            rst = optimize.fsolve( func=func, 
+                                   x0=x0,
+                                   full_output=True )
             return rst
         
         for i in range( self.dim ):
@@ -123,12 +123,12 @@ class NatafTransformation:
                 if self.rhoX[ i, j ] == 0:
                     continue
 
-                termI = ( self.distObjs[ i ].ppf( sp.stats.norm.cdf( intPointsXX ) ) - 
+                termI = ( self.distObjs[ i ].ppf( stats.norm.cdf( intPointsXX ) ) - 
                           self.distObjs[ i ].mean() ) / self.distObjs[ i ].std()
                 termI[ termI == np.inf ] = np.sqrt( np.finfo(float).max ) - 1
                 termI[ termI == -np.inf ] = -np.sqrt( np.finfo(float).max ) + 1
 
-                termJ = ( self.distObjs[ j ].ppf( sp.stats.norm.cdf( intPointsYY ) ) - 
+                termJ = ( self.distObjs[ j ].ppf( stats.norm.cdf( intPointsYY ) ) - 
                           self.distObjs[ j ].mean() ) / self.distObjs[ j ].std()
                 termJ[ termJ == np.inf ] = np.sqrt( np.finfo(float).max ) - 1
                 termJ[ termJ == -np.inf ] = -np.sqrt( np.finfo(float).max ) + 1
@@ -211,7 +211,7 @@ class NatafTransformation:
         # X -> Z
         Z = np.zeros_like( X )
         for d in range( self.dim ):
-            Z[ d ] = sp.stats.norm.ppf( self.distObjs[ d ].cdf( X[ d ] ) )
+            Z[ d ] = stats.norm.ppf( self.distObjs[ d ].cdf( X[ d ] ) )
 
         # Z -> U
         U = np.linalg.solve( self.L, Z.T ).T
@@ -219,7 +219,7 @@ class NatafTransformation:
         # Jacobian = diag[ phi( y_i ) / f( x_i )] * L
         diagMat = np.zeros( ( self.dim, self.dim ) )
         for d in range( self.dim ):
-            diagMat[ d, d ] = sp.stats.norm.pdf( Z[ d ] ) / \
+            diagMat[ d, d ] = stats.norm.pdf( Z[ d ] ) / \
                 self.distObjs[ d ].pdf( X[ d ] )
         J = np.dot( diagMat, self.L )
         
@@ -269,13 +269,13 @@ class NatafTransformation:
         # Z -> X
         X = np.zeros_like( U )
         for d in range( self.dim ):
-            X[ d ] = self.distObjs[ d ].ppf( sp.stats.norm.cdf( Z[ d ] ) )
+            X[ d ] = self.distObjs[ d ].ppf( stats.norm.cdf( Z[ d ] ) )
 
         # Jacobina = L ^ ( -1 ) * diag[ f( x_i ) / phi( y_i ) ] 
         diagMat = np.zeros( ( self.dim, self.dim ) )
         for d in range( self.dim ):
             diagMat[ d, d ] = self.distObjs[ d ].pdf( X[ d ] ) / \
-                sp.stats.norm.pdf( Z[ d ] )
+                stats.norm.pdf( Z[ d ] )
         J = np.linalg.solve( self.L, diagMat )
 
         return X, J 
@@ -319,10 +319,10 @@ class NatafTransformation:
         mu = np.zeros( self.dim )
         std = np.array( [ dist.std() for dist in self.distObjs ] )
         cov = np.diag( std ) @ self.rhoZ @ np.diag( std )
-        mv = sp.stats.multivariate_normal( mean=mu, cov=cov )
+        mv = stats.multivariate_normal( mean=mu, cov=cov )
         for d in range( self.dim ):
-            Z[ d ] = sp.stats.norm.ppf( self.distObjs[ d ].cdf( X[ d ] ) )
-            phi[ d ] = sp.stats.norm.pdf( Z[ d ] )
+            Z[ d ] = stats.norm.ppf( self.distObjs[ d ].cdf( X[ d ] ) )
+            phi[ d ] = stats.norm.pdf( Z[ d ] )
             y[ d ] = self.distObjs[ d ].pdf( X[ d ] )
         rst = 0
         if not np.isclose( np.prod( phi ), 0 ):
@@ -366,9 +366,9 @@ class NatafTransformation:
         mu = np.zeros( self.dim )
         std = np.array( [ dist.std() for dist in self.distObjs ] )
         cov = np.diag( std ) @ self.rhoZ @ np.diag( std )
-        mv = sp.stats.multivariate_normal( mean=mu, cov=cov )
+        mv = stats.multivariate_normal( mean=mu, cov=cov )
         for d in range( self.dim ):
-            Z[ d ] = sp.stats.norm.ppf( self.distObjs[ d ].cdf( X[ d ] ) )
+            Z[ d ] = stats.norm.ppf( self.distObjs[ d ].cdf( X[ d ] ) )
 
         rst = mv.cdf( Z )
         return rst

--- a/src/ffpack/rrm/firstOrderReliabilityMethod.py
+++ b/src/ffpack/rrm/firstOrderReliabilityMethod.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import numpy as np
-import scipy as sp
+from scipy import misc, stats, optimize
 from ffpack.config import globalConfig 
 from ffpack import rpm
 
@@ -62,7 +62,7 @@ def formHLRF( dim, g, dg, distObjs, corrMat, iter=1000, tol=1e-6 ):
     >>> dim = 2
     >>> g = lambda X: -np.sum( X ) + 1
     >>> dg = [ lambda X: -1, lambda X: -1 ]
-    >>> distObjs = [ sp.stats.norm(), sp.stats.norm() ]
+    >>> distObjs = [ stats.norm(), stats.norm() ]
     >>> corrMat = np.eye( dim )
     >>> beta, pf, uCoord, xCoord = rrm.formHLRF( dim, g, dg, distObjs, corrMat )
     '''
@@ -95,8 +95,8 @@ def formHLRF( dim, g, dg, distObjs, corrMat, iter=1000, tol=1e-6 ):
         def wraps( x ):
             args[ var ] = x
             return func( args )
-        return sp.misc.derivative( wraps, points[ var ], 
-                                   dx=1 / np.power( 10, globalConfig.dtol ) )
+        return misc.derivative( wraps, points[ var ], 
+                                dx=1 / np.power( 10, globalConfig.dtol ) )
     
     def dgWrap( g, var=0 ):
         def dgi( mus ):
@@ -130,7 +130,7 @@ def formHLRF( dim, g, dg, distObjs, corrMat, iter=1000, tol=1e-6 ):
             break
     
     beta = betas[ idx ]
-    pf = sp.stats.norm.cdf( -beta )
+    pf = stats.norm.cdf( -beta )
     uCoord = Us[ idx ]
     xCoord, _ = natafTrans.getX( uCoord )
     return beta, pf, uCoord, xCoord
@@ -178,7 +178,7 @@ def formCOPT( dim, g, distObjs, corrMat ):
     >>> from ffpack.rrm import formCOPT
     >>> dim = 2
     >>> g = lambda X: -np.sum( X ) + 1
-    >>> distObjs = [ sp.stats.norm(), sp.stats.norm() ]
+    >>> distObjs = [ stats.norm(), stats.norm() ]
     >>> corrMat = np.eye( dim )
     >>> beta, pf, uCoord, xCoord = rrm.formCOPT( dim, g, distObjs, corrMat )
     '''
@@ -214,9 +214,9 @@ def formCOPT( dim, g, distObjs, corrMat ):
     cons = ( { "type": "eq",
                "fun": lambda U: g( natafTrans.getX( U )[ 0 ] ) } )
     
-    rst = sp.optimize.minimize( f, u, constraints=cons )
+    rst = optimize.minimize( f, u, constraints=cons )
     beta = rst.fun
-    pf = sp.stats.norm.cdf( -beta )
+    pf = stats.norm.cdf( -beta )
     uCoord = rst.x
     xCoord = natafTrans.getX( uCoord )[ 0 ]
     return beta, pf, uCoord, xCoord

--- a/src/ffpack/rrm/firstOrderSecondMoment.py
+++ b/src/ffpack/rrm/firstOrderSecondMoment.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import numpy as np
-import scipy as sp
+from scipy import misc, stats
 from ffpack.config import globalConfig 
 
 def fosm( dim, g, dg, mus, sigmas ):
@@ -63,7 +63,7 @@ def fosm( dim, g, dg, mus, sigmas ):
         def wraps( x ):
             args[ var ] = x
             return func( args )
-        return sp.misc.derivative( wraps, points[ var ], 
+        return misc.derivative( wraps, points[ var ], 
                                    dx=1 / np.power( 10, globalConfig.dtol ) )
     
     def dgWrap( g, var=0 ):
@@ -78,6 +78,6 @@ def fosm( dim, g, dg, mus, sigmas ):
     a = np.array( [ dgi( mus ) for dgi in dg ] )
     aSigmas = np.multiply( a, sigmas )
     beta = lsfRst / np.sqrt( np.sum( np.square( aSigmas ) ) )
-    pf = sp.stats.norm.cdf( -beta )
+    pf = stats.norm.cdf( -beta )
 
     return beta, pf

--- a/tests/rpm/test_rpm_nataf.py
+++ b/tests/rpm/test_rpm_nataf.py
@@ -2,7 +2,7 @@
 
 from ffpack import rpm
 import numpy as np
-import scipy as sp
+from scipy import stats
 import pytest
 from unittest.mock import patch
 
@@ -21,7 +21,7 @@ def test_NatafTransformation_initWithDisObjsEmpty_valueError():
 
 
 def test_NatafTransformation_initWithDisObjsDimMismatch_valueError():
-    X1 = sp.stats.norm()
+    X1 = stats.norm()
 
     rho = 0.5
 
@@ -33,8 +33,8 @@ def test_NatafTransformation_initWithDisObjsDimMismatch_valueError():
 
 
 def test_NatafTransformation_initWithOneDimCorrMat_valueError():
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     rho = 0.5
 
@@ -46,8 +46,8 @@ def test_NatafTransformation_initWithOneDimCorrMat_valueError():
 
 
 def test_NatafTransformation_initWithCorrMatDiagNotOne_valueError():
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     rho = 0.5
 
@@ -59,8 +59,8 @@ def test_NatafTransformation_initWithCorrMatDiagNotOne_valueError():
 
 
 def test_NatafTransformation_initWithCorrMatNotSymm_valueError():
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     rho = 0.5
 
@@ -72,8 +72,8 @@ def test_NatafTransformation_initWithCorrMatNotSymm_valueError():
 
 
 def test_NatafTransformation_initWithCorrMatNotPositiveDefinite_valueError():
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     rho = -1.2
 
@@ -85,8 +85,8 @@ def test_NatafTransformation_initWithCorrMatNotPositiveDefinite_valueError():
 
 
 def test_NatafTransformation_getXWithULengthMismatch_valueError():
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     rho = 0.5
 
@@ -99,8 +99,8 @@ def test_NatafTransformation_getXWithULengthMismatch_valueError():
 
 
 def test_NatafTransformation_getXWithUDimMismatch_valueError():
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     rho = 0.5
 
@@ -113,8 +113,8 @@ def test_NatafTransformation_getXWithUDimMismatch_valueError():
 
 
 def test_NatafTransformation_getUWithXLengthMismatch_valueError():
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     rho = 0.5
 
@@ -127,8 +127,8 @@ def test_NatafTransformation_getUWithXLengthMismatch_valueError():
 
 
 def test_NatafTransformation_getUWithXDimMismatch_valueError():
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     rho = 0.5
 
@@ -141,8 +141,8 @@ def test_NatafTransformation_getUWithXDimMismatch_valueError():
 
 
 def test_NatafTransformation_pdfWithXLengthMismatch_valueError():
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     rho = 0.5
 
@@ -155,8 +155,8 @@ def test_NatafTransformation_pdfWithXLengthMismatch_valueError():
 
 
 def test_NatafTransformation_pdfWithXDimMismatch_valueError():
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     rho = 0.5
 
@@ -169,8 +169,8 @@ def test_NatafTransformation_pdfWithXDimMismatch_valueError():
 
 
 def test_NatafTransformation_cdfWithXLengthMismatch_valueError():
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     rho = 0.5
 
@@ -183,8 +183,8 @@ def test_NatafTransformation_cdfWithXLengthMismatch_valueError():
 
 
 def test_NatafTransformation_cdfWithXDimMismatch_valueError():
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     rho = 0.5
 
@@ -203,8 +203,8 @@ def test_NatafTransformation_cdfWithXDimMismatch_valueError():
                                    0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 
                                    0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95 ] )
 def test_NatafTransformation_twoNormalVariablesCase_rhoZEqualCorrMat( rho ):
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     distObjs = [ X1, X2 ]
     corrMat = [ [ 1.0, rho ], [ rho, 1.0 ] ]
@@ -217,9 +217,9 @@ def test_NatafTransformation_twoNormalVariablesCase_rhoZEqualCorrMat( rho ):
                                    0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 
                                    0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95 ] )
 def test_NatafTransformation_threeNormalVariablesCase_rhoZEqualCorrMat( rho ):
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
-    X3 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
+    X3 = stats.norm()
 
     distObjs = [ X1, X2, X3 ]
     corrMat = [ [ 1.0, rho, rho ], [ rho, 1.0, rho ], [ rho, rho, 1.0 ] ]
@@ -229,8 +229,8 @@ def test_NatafTransformation_threeNormalVariablesCase_rhoZEqualCorrMat( rho ):
 
 
 def test_NatafTransformation_normAndExpVariablesCase_2dRhoZ( ):
-    X1 = sp.stats.norm()
-    X2 = sp.stats.expon()
+    X1 = stats.norm()
+    X2 = stats.expon()
     distObjs = [ X1, X2 ]
 
     rho = -0.8
@@ -283,8 +283,8 @@ def test_NatafTransformation_normAndExpVariablesCase_2dRhoZ( ):
 
 
 def test_NatafTransformation_normAndGammaVariablesCase_2dRhoZ( ):
-    X1 = sp.stats.norm()
-    X2 = sp.stats.gamma( 2 )
+    X1 = stats.norm()
+    X2 = stats.gamma( 2 )
     distObjs = [ X1, X2 ]
 
     rho = -0.8
@@ -337,8 +337,8 @@ def test_NatafTransformation_normAndGammaVariablesCase_2dRhoZ( ):
 
 
 def test_NatafTransformation_expAndGammaVariablesCase_2dRhoZ( ):
-    X1 = sp.stats.expon()
-    X2 = sp.stats.gamma( 2 )
+    X1 = stats.expon()
+    X2 = stats.gamma( 2 )
     distObjs = [ X1, X2 ]
 
     rho = -0.7
@@ -391,8 +391,8 @@ def test_NatafTransformation_expAndGammaVariablesCase_2dRhoZ( ):
 
 
 def test_NatafTransformation_normAndGumbelVariablesCase_2dRhoZ( ):
-    X1 = sp.stats.norm()
-    X2 = sp.stats.gumbel_r( 2 )
+    X1 = stats.norm()
+    X2 = stats.gumbel_r( 2 )
     distObjs = [ X1, X2 ]
 
     rho = -0.7
@@ -445,9 +445,9 @@ def test_NatafTransformation_normAndGumbelVariablesCase_2dRhoZ( ):
 
 
 def test_NatafTransformation_normExpAndGumbelVariablesCase_2dRhoZ( ):
-    X1 = sp.stats.norm()
-    X2 = sp.stats.gumbel_r( 2 )
-    X3 = sp.stats.expon()
+    X1 = stats.norm()
+    X2 = stats.gumbel_r( 2 )
+    X3 = stats.expon()
     distObjs = [ X1, X2, X3 ]
 
     rho = -0.2
@@ -492,9 +492,9 @@ def test_NatafTransformation_normExpAndGumbelVariablesCase_2dRhoZ( ):
 
 
 def test_NatafTransformation_expGammaAndGumbelVariablesCase_2dRhoZ( ):
-    X1 = sp.stats.gumbel_r( 2 )
-    X2 = sp.stats.expon()
-    X3 = sp.stats.gamma( 2 )
+    X1 = stats.gumbel_r( 2 )
+    X2 = stats.expon()
+    X3 = stats.gamma( 2 )
     distObjs = [ X1, X2, X3 ]
 
     rho = -0.2
@@ -539,9 +539,9 @@ def test_NatafTransformation_expGammaAndGumbelVariablesCase_2dRhoZ( ):
 
 
 def test_NatafTransformation_normalExpAndGammaVariablesPositiveRho_outputScalar( ):
-    X1 = sp.stats.norm()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.gamma( 2 )
+    X1 = stats.norm()
+    X2 = stats.expon()
+    X3 = stats.gamma( 2 )
     distObjs = [ X1, X2, X3 ]
 
     rho = 0.5
@@ -572,9 +572,9 @@ def test_NatafTransformation_normalExpAndGammaVariablesPositiveRho_outputScalar(
 
 
 def test_NatafTransformation_normalExpAndGammaVariablesNegativeRho_outputScalar( ):
-    X1 = sp.stats.norm()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.gamma( 2 )
+    X1 = stats.norm()
+    X2 = stats.expon()
+    X3 = stats.gamma( 2 )
     distObjs = [ X1, X2, X3 ]
 
     rho = -0.2
@@ -605,9 +605,9 @@ def test_NatafTransformation_normalExpAndGammaVariablesNegativeRho_outputScalar(
 
 
 def test_NatafTransformation_normalExpAndGammaVariablesZeroRho_outputScalar( ):
-    X1 = sp.stats.norm()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.gamma( 2 )
+    X1 = stats.norm()
+    X2 = stats.expon()
+    X3 = stats.gamma( 2 )
     distObjs = [ X1, X2, X3 ]
 
     rho = 0.0
@@ -640,8 +640,8 @@ def test_NatafTransformation_normalExpAndGammaVariablesZeroRho_outputScalar( ):
 @patch( "numpy.random.randn" )
 def test_NatafTransformation_sampleDataPoint_1dArray( mock_randn ):
     mock_randn.return_value = [ 1.0, 1.0 ]
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
 
     distObjs = [ X1, X2 ]
     corrMat = [ [ 1.0, 0.0 ], [ 0.0, 1.0 ] ]

--- a/tests/rrm/test_rrm_firstOrderReliabilityMethod.py
+++ b/tests/rrm/test_rrm_firstOrderReliabilityMethod.py
@@ -2,7 +2,7 @@
 
 from ffpack import rrm
 import numpy as np
-import scipy as sp
+from scipy import stats
 import pytest
 from unittest.mock import patch
 from ffpack.rpm import NatafTransformation
@@ -18,8 +18,8 @@ def test_formHLRF_dimLessOneCase_valueError( ):
         return -np.sum( X ) + 1
 
     dg = [ lambda X: -1, lambda X: -1 ] 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = np.eye( dim )
     with pytest.raises( ValueError ):
@@ -33,7 +33,7 @@ def test_formHLRF_distObjsDimMismatchCase_valueError( ):
         return -np.sum( X ) + 1
 
     dg = [ lambda X: -1, lambda X: -1 ] 
-    X1 = sp.stats.norm()
+    X1 = stats.norm()
     distObjs = [ X1 ]
     corrMat = np.eye( dim )
     with pytest.raises( ValueError ):
@@ -47,8 +47,8 @@ def test_formHLRF_corrMatDimMismatchCase_valueError( ):
         return -np.sum( X ) + 1
 
     dg = [ lambda X: -1, lambda X: -1 ] 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = [ [ 1.0 ], [ 1.0 ] ]
     with pytest.raises( ValueError ):
@@ -62,8 +62,8 @@ def test_formHLRF_corrMatNotTwoDimCase_valueError( ):
         return -np.sum( X ) + 1
 
     dg = [ lambda X: -1, lambda X: -1 ] 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = [ 1.0, 2.0 ]
     with pytest.raises( ValueError ):
@@ -77,8 +77,8 @@ def test_formHLRF_corrMatNotSymmCase_valueError( ):
         return -np.sum( X ) + 1
 
     dg = [ lambda X: -1, lambda X: -1 ] 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = [ [ 1.0, 0.5 ], [ -0.5, 1.0 ] ]
     with pytest.raises( ValueError ):
@@ -92,8 +92,8 @@ def test_formHLRF_corrMatNotPositiveDefiniteCase_valueError( ):
         return -np.sum( X ) + 1
 
     dg = [ lambda X: -1, lambda X: -1 ] 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = [ [ 1.0, -1.2 ], [ -1.2, 1.0 ] ]
     with pytest.raises( ValueError ):
@@ -107,8 +107,8 @@ def test_formHLRF_corrMatDiagNotOneCase_valueError( ):
         return -np.sum( X ) + 1
 
     dg = [ lambda X: -1, lambda X: -1 ] 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = [ [ 1.0, 0.0 ], [ 0.0, 2.0 ] ]
     with pytest.raises( ValueError ):
@@ -124,8 +124,8 @@ def test_formHLRF_twoNormalLinearMockCase1_scalar( mock_getX, dgExists ):
         return -np.sum( X ) + 1
 
     dg = [ lambda X: -1, lambda X: -1 ] if dgExists else None
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = np.eye( dim )
     mock_getX.return_value = ( np.array( [ 1.0, 1.0 ] ), 
@@ -133,7 +133,7 @@ def test_formHLRF_twoNormalLinearMockCase1_scalar( mock_getX, dgExists ):
     calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, distObjs, 
                                                          corrMat, iter=1 )
     expectedBeta = np.sqrt( 2 ) / 2
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.5, 0.5 ]
     expectedXCoord = [ 1.0, 1.0 ]
     np.testing.assert_allclose( np.round( expectedBeta, 5 ), np.round( calBeta, 5 ) )
@@ -153,8 +153,8 @@ def test_formHLRF_twoNormalLinearMockCase2_scalar( mock_getX, dgExists ):
         return -np.sum( X ) + 1
 
     dg = [ lambda X: -1, lambda X: -1 ] if dgExists else None
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = np.eye( dim )
     mock_getX.return_value = ( np.array( [ 2.0, 2.0 ] ), 
@@ -162,7 +162,7 @@ def test_formHLRF_twoNormalLinearMockCase2_scalar( mock_getX, dgExists ):
     calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, distObjs, 
                                                          corrMat, iter=1 )
     expectedBeta = -1 * np.sqrt( 2 ) / 2
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ -0.5, -0.5 ]
     expectedXCoord = [ 2.0, 2.0 ]
     np.testing.assert_allclose( np.round( expectedBeta, 5 ), np.round( calBeta, 5 ) )
@@ -182,8 +182,8 @@ def test_formHLRF_twoNormalNonLinearMockCase_scalar( mock_getX, dgExists ):
         return -1 * X[ 0 ] - 2 * X[ 1 ] * X[ 1 ] + 20
 
     dg = [ lambda X: -1, lambda X: -4 * X[ 1 ] ] if dgExists else None
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = np.eye( dim )
     mock_getX.return_value = ( np.array( [ 1.0, 1.0 ] ), 
@@ -191,7 +191,7 @@ def test_formHLRF_twoNormalNonLinearMockCase_scalar( mock_getX, dgExists ):
     calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, distObjs, 
                                                          corrMat, iter=1 )
     expectedBeta = 22 / np.sqrt( 17 )
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 22 / 17, 88 / 17 ]
     expectedXCoord = [ 1.0, 1.0 ]
     np.testing.assert_allclose( np.round( expectedBeta, 5 ), np.round( calBeta, 5 ) )
@@ -210,14 +210,14 @@ def test_formHLRF_twoNormalLinearCase_scalar( dgExists ):
         return -np.sum( X ) + 1
 
     dg = [ lambda X: -1, lambda X: -1 ] if dgExists else None
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, 
                                                          distObjs, corrMat )
     expectedBeta = np.sqrt( 2 ) / 2
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.5, 0.5 ]
     expectedXCoord = [ 0.5, 0.5 ]
     np.testing.assert_allclose( np.round( expectedBeta, 5 ), np.round( calBeta, 5 ) )
@@ -236,14 +236,14 @@ def test_formHLRF_twoNormalNonLinearCase1_scalar( dgExists ):
         return -1 * X[ 0 ] - 2 * X[ 1 ] * X[ 1 ] + 20
 
     dg = [ lambda X: -1, lambda X: -4 * X[ 1 ] ] if dgExists else None
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, 
                                                          distObjs, corrMat )
     expectedBeta = 3.152380053229633
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.24999987, 3.14245128 ]
     expectedXCoord = [ 0.24999987, 3.14245128 ]
     np.testing.assert_allclose( np.round( expectedBeta, 5 ), np.round( calBeta, 5 ) )
@@ -262,14 +262,14 @@ def test_formHLRF_twoNormalNonLinearCase2_scalar( dgExists ):
         return -2 * X[ 0 ] * X[ 0 ] - 2 * X[ 1 ] * X[ 1 ] + 10
 
     dg = [ lambda X: -4 * X[ 0 ], lambda X: -4 * X[ 1 ] ] if dgExists else None
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, 
                                                          distObjs, corrMat )
     expectedBeta = 2.23606797749979
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 1.58113883, 1.58113883 ]
     expectedXCoord = [ 1.58113883, 1.58113883 ]
     np.testing.assert_allclose( np.round( expectedBeta, 5 ), np.round( calBeta, 5 ) )
@@ -288,15 +288,15 @@ def test_formHLRF_threeExpLinearCase_scalar( dgExists ):
         return -np.sum( X ) + 3
 
     dg = [ lambda X: -1, lambda X: -1, lambda X: -1 ] if dgExists else None
-    X1 = sp.stats.expon()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.expon()
+    X1 = stats.expon()
+    X2 = stats.expon()
+    X3 = stats.expon()
     distObjs = [ X1, X2, X3 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, 
                                                          distObjs, corrMat )
     expectedBeta = 0.5845237835400737
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.33748047, 0.33748047, 0.33748047 ]
     expectedXCoord = [ 1.00000564, 1.00000564, 1.00000564 ]
     np.testing.assert_allclose( np.round( expectedBeta, 5 ), np.round( calBeta, 5 ) )
@@ -316,15 +316,15 @@ def test_formHLRF_threeExpNonLinearCase_scalar( dgExists ):
 
     dg = [ lambda X: -1, lambda X: -2 * X[ 1 ], lambda X: -2 * X[ 2 ] ] \
         if dgExists else None
-    X1 = sp.stats.expon()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.expon()
+    X1 = stats.expon()
+    X2 = stats.expon()
+    X3 = stats.expon()
     distObjs = [ X1, X2, X3 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, 
                                                          distObjs, corrMat )
     expectedBeta = 0.5576668962820067
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.1549542, 0.37880177, 0.37880177 ]
     expectedXCoord = [ 0.82455805, 1.04293863, 1.04293863 ]
     np.testing.assert_allclose( np.round( expectedBeta, 5 ), np.round( calBeta, 5 ) )
@@ -343,15 +343,15 @@ def test_formHLRF_twoExpOneNormalLinearCase_scalar( dgExists ):
         return -X[ 0 ] - X[ 1 ] - X[ 2 ] + 3
 
     dg = [ lambda X: -1, lambda X: -1, lambda X: -1 ] if dgExists else None
-    X1 = sp.stats.expon()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.norm()
+    X1 = stats.expon()
+    X2 = stats.expon()
+    X3 = stats.norm()
     distObjs = [ X1, X2, X3 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, 
                                                          distObjs, corrMat )
     expectedBeta = 0.9406456373861823
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.57235988, 0.57235988, 0.47918946 ]
     expectedXCoord = [ 1.26040527, 1.26040527, 0.47918946 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
@@ -371,15 +371,15 @@ def test_formHLRF_twoExpOneNormalNonLinearCase_scalar( dgExists ):
 
     dg = [ lambda X: -1, lambda X: -2 * X[ 1 ], lambda X: -2 * X[ 2 ] ] \
         if dgExists else None
-    X1 = sp.stats.expon()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.norm()
+    X1 = stats.expon()
+    X2 = stats.expon()
+    X3 = stats.norm()
     distObjs = [ X1, X2, X3 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, 
                                                          distObjs, corrMat )
     expectedBeta = 0.758619677951736
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 1.73566795e-01, 7.38497382e-01, 6.22122748e-06 ]
     expectedXCoord = [ 8.41408320e-01, 1.46921465e+00, 6.22122748e-06 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
@@ -399,16 +399,16 @@ def test_formHLRF_twoExpOneNormalOneGammaLinearCase_scalar( dgExists ):
 
     dg = [ lambda X: -1, lambda X: -1, lambda X: -1, lambda X: -1 ] \
         if dgExists else None
-    X1 = sp.stats.expon()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.norm()
-    X4 = sp.stats.gamma( 2 )
+    X1 = stats.expon()
+    X2 = stats.expon()
+    X3 = stats.norm()
+    X4 = stats.gamma( 2 )
     distObjs = [ X1, X2, X3, X4 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, 
                                                          distObjs, corrMat )
     expectedBeta = 0.44811639358366484
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.18690136, 0.18690136, 0.20303017, 0.29953768 ]
     expectedXCoord = [ 0.85362352, 0.85362352, 0.20303017, 2.08972279 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
@@ -430,16 +430,16 @@ def test_formHLRF_twoExpOneNormalOneGammaNonLinearCase_scalar( dgExists ):
            lambda X: -1, 
            lambda X: -1, 
            lambda X: -2 * X[ 3 ] ] if dgExists else None
-    X1 = sp.stats.expon()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.norm()
-    X4 = sp.stats.gamma( 2 )
+    X1 = stats.expon()
+    X2 = stats.expon()
+    X3 = stats.norm()
+    X4 = stats.gamma( 2 )
     distObjs = [ X1, X2, X3, X4 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, 
                                                          distObjs, corrMat )
     expectedBeta = 0.35867913670082807
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.06679387, 0.04387002, 0.05311046, 0.34560672 ]
     expectedXCoord = [ 0.74787182, 0.72876606, 0.05311046, 2.15842795 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
@@ -460,8 +460,8 @@ def test_formCOPT_dimLessOneCase_valueError( ):
     def g( X ):
         return -np.sum( X ) + 1
 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = np.eye( dim )
     with pytest.raises( ValueError ):
@@ -474,7 +474,7 @@ def test_formCOPT_distObjsDimMismatchCase_valueError( ):
     def g( X ):
         return -np.sum( X ) + 1
 
-    X1 = sp.stats.norm()
+    X1 = stats.norm()
     distObjs = [ X1 ]
     corrMat = np.eye( dim )
     with pytest.raises( ValueError ):
@@ -487,8 +487,8 @@ def test_formCOPT_corrMatDimMismatchCase_valueError( ):
     def g( X ):
         return -np.sum( X ) + 1
 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = [ [ 1.0 ], [ 1.0 ] ]
     with pytest.raises( ValueError ):
@@ -501,8 +501,8 @@ def test_formCOPT_corrMatNotTwoDimCase_valueError( ):
     def g( X ):
         return -np.sum( X ) + 1
 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = [ 1.0, 2.0 ]
     with pytest.raises( ValueError ):
@@ -515,8 +515,8 @@ def test_formCOPT_corrMatNotSymmCase_valueError( ):
     def g( X ):
         return -np.sum( X ) + 1
 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = [ [ 1.0, 0.5 ], [ -0.5, 1.0 ] ]
     with pytest.raises( ValueError ):
@@ -529,8 +529,8 @@ def test_formCOPT_corrMatNotPositiveDefiniteCase_valueError( ):
     def g( X ):
         return -np.sum( X ) + 1
 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = [ [ 1.0, -1.2 ], [ -1.2, 1.0 ] ]
     with pytest.raises( ValueError ):
@@ -543,8 +543,8 @@ def test_formCOPT_corrMatDiagNotOneCase_valueError( ):
     def g( X ):
         return -np.sum( X ) + 1
 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = [ [ 1.0, 0.0 ], [ 0.0, 2.0 ] ]
     with pytest.raises( ValueError ):
@@ -557,13 +557,13 @@ def test_formCOPT_twoNormalLinearCase_scalar( ):
     def g( X ):
         return -np.sum( X ) + 1
 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formCOPT( dim, g, distObjs, corrMat )
     expectedBeta = np.sqrt( 2 ) / 2
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.5, 0.5 ]
     expectedXCoord = [ 0.5, 0.5 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
@@ -580,13 +580,13 @@ def test_formCOPT_twoNormalNonLinearCase1_scalar():
     def g( X ):
         return -1 * X[ 0 ] - 2 * X[ 1 ] * X[ 1 ] + 20
 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formCOPT( dim, g, distObjs, corrMat )
     expectedBeta = 3.152380053229633
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.24999987, 3.14245128 ]
     expectedXCoord = [ 0.24999987, 3.14245128 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
@@ -603,13 +603,13 @@ def test_formCOPT_twoNormalNonLinearCase2_scalar():
     def g( X ):
         return -2 * X[ 0 ] * X[ 0 ] - 2 * X[ 1 ] * X[ 1 ] + 10
 
-    X1 = sp.stats.norm()
-    X2 = sp.stats.norm()
+    X1 = stats.norm()
+    X2 = stats.norm()
     distObjs = [ X1, X2 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formCOPT( dim, g, distObjs, corrMat )
     expectedBeta = 2.23606797749979
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 1.58113883, 1.58113883 ]
     expectedXCoord = [ 1.58113883, 1.58113883 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
@@ -626,14 +626,14 @@ def test_formCOPT_threeExpLinearCase_scalar():
     def g( X ):
         return -np.sum( X ) + 3
 
-    X1 = sp.stats.expon()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.expon()
+    X1 = stats.expon()
+    X2 = stats.expon()
+    X3 = stats.expon()
     distObjs = [ X1, X2, X3 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formCOPT( dim, g, distObjs, corrMat )
     expectedBeta = 0.5845237835400737
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.33748047, 0.33748047, 0.33748047 ]
     expectedXCoord = [ 1.00000564, 1.00000564, 1.00000564 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
@@ -650,14 +650,14 @@ def test_formCOPT_threeExpNonLinearCase_scalar():
     def g( X ):
         return -X[ 0 ] - X[ 1 ] * X[ 1 ] - X[ 2 ] * X[ 2 ] + 3
 
-    X1 = sp.stats.expon()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.expon()
+    X1 = stats.expon()
+    X2 = stats.expon()
+    X3 = stats.expon()
     distObjs = [ X1, X2, X3 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formCOPT( dim, g, distObjs, corrMat )
     expectedBeta = 0.5576668962820067
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.1549542, 0.37880177, 0.37880177 ]
     expectedXCoord = [ 0.82455805, 1.04293863, 1.04293863 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
@@ -674,14 +674,14 @@ def test_formCOPT_twoExpOneNormalLinearCase_scalar():
     def g( X ):
         return -X[ 0 ] - X[ 1 ] - X[ 2 ] + 3
 
-    X1 = sp.stats.expon()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.norm()
+    X1 = stats.expon()
+    X2 = stats.expon()
+    X3 = stats.norm()
     distObjs = [ X1, X2, X3 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formCOPT( dim, g, distObjs, corrMat )
     expectedBeta = 0.9406456373861823
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.57235988, 0.57235988, 0.47918946 ]
     expectedXCoord = [ 1.26040527, 1.26040527, 0.47918946 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
@@ -698,14 +698,14 @@ def test_formCOPT_twoExpOneNormalNonLinearCase_scalar():
     def g( X ):
         return -X[ 0 ] - X[ 1 ] * X[ 1 ] - X[ 2 ] * X[ 2 ] + 3
 
-    X1 = sp.stats.expon()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.norm()
+    X1 = stats.expon()
+    X2 = stats.expon()
+    X3 = stats.norm()
     distObjs = [ X1, X2, X3 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formCOPT( dim, g, distObjs, corrMat )
     expectedBeta = 0.758619677951736
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 1.73566795e-01, 7.38497382e-01, 6.22122748e-06 ]
     expectedXCoord = [ 8.41408320e-01, 1.46921465e+00, 6.22122748e-06 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
@@ -722,15 +722,15 @@ def test_formCOPT_twoExpOneNormalOneGammaLinearCase_scalar():
     def g( X ):
         return -X[ 0 ] - X[ 1 ] - X[ 2 ] - X[ 3 ] + 6
 
-    X1 = sp.stats.expon()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.norm()
-    X4 = sp.stats.gamma( 2 )
+    X1 = stats.expon()
+    X2 = stats.expon()
+    X3 = stats.norm()
+    X4 = stats.gamma( 2 )
     distObjs = [ X1, X2, X3, X4 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formCOPT( dim, g, distObjs, corrMat )
     expectedBeta = 1.2634328903061505
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.54715364, 0.54715364, 0.46536261, 0.88371154 ]
     expectedXCoord = [ 1.23053381, 1.23053381, 0.46536261, 3.07356976 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
@@ -747,15 +747,15 @@ def test_formCOPT_twoExpOneNormalOneGammaNonLinearCase_scalar():
     def g( X ):
         return -X[ 0 ] * X[ 0 ] - X[ 1 ] - X[ 2 ] - X[ 3 ] * X[ 3 ] + 6
 
-    X1 = sp.stats.expon()
-    X2 = sp.stats.expon()
-    X3 = sp.stats.norm()
-    X4 = sp.stats.gamma( 2 )
+    X1 = stats.expon()
+    X2 = stats.expon()
+    X3 = stats.norm()
+    X4 = stats.gamma( 2 )
     distObjs = [ X1, X2, X3, X4 ]
     corrMat = np.eye( dim )
     calBeta, calPf, calUCoord, calXCoord = rrm.formCOPT( dim, g, distObjs, corrMat )
     expectedBeta = 0.35867913670082807
-    expectedPf = sp.stats.norm.cdf( -expectedBeta )
+    expectedPf = stats.norm.cdf( -expectedBeta )
     expectedUCoord = [ 0.06679387, 0.04387002, 0.05311046, 0.34560672 ]
     expectedXCoord = [ 0.74787182, 0.72876606, 0.05311046, 2.15842795 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )


### PR DESCRIPTION
In the previous implementation, the scipy is imported as sp.
Here, we changed it to specific module name.
For example:

```
import scipy as sp
sp.stats.norm()
```
is replaced by,

```
from scipy import stats
stats.norm()
```