### PR TITLE
bug/updated deprecated issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ffpack"
-version = "0.3.0"
+version = "0.3.1"
 description = "Fatigue and fracture package"
 authors = [
     "Dongping Zhu",
@@ -22,7 +22,7 @@ homepage = "https://pypi.org/project/ffpack"
 repository = "https://github.com/dpzhuX/ffpack"
 documentation = "https://ffpack.readthedocs.io/en/latest/"
 
-keywords = [ "fatigue", "fracture", "counting" ]
+keywords = [ "fatigue", "fracture", "load", "reliability" ]
 
 classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
@@ -33,7 +33,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-scipy = "^1.9"
+scipy = "^1.10"
 
 [tool.pytest.ini_options]
 addopts = [

--- a/src/ffpack/rrm/firstOrderReliabilityMethod.py
+++ b/src/ffpack/rrm/firstOrderReliabilityMethod.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 import numpy as np
-from scipy import misc, stats, optimize
+from scipy import stats, optimize
+from ffpack.utils import derivative
 from ffpack.config import globalConfig 
 from ffpack import rpm
 
@@ -101,8 +102,8 @@ def formHLRF( dim, g, dg, distObjs, corrMat, iter=1000, tol=1e-6,
         def wraps( x ):
             args[ var ] = x
             return func( args )
-        return misc.derivative( wraps, points[ var ], 
-                                dx=1 / np.power( 10, globalConfig.dtol ) )
+        return derivative( wraps, points[ var ], 
+                           dx=1 / np.power( 10, globalConfig.dtol ) )
     
     def dgWrap( g, var=0 ):
         def dgi( mus ):

--- a/src/ffpack/rrm/firstOrderSecondMoment.py
+++ b/src/ffpack/rrm/firstOrderSecondMoment.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 import numpy as np
-from scipy import misc, stats
+from scipy import stats
+from ffpack.utils import derivative
 from ffpack.config import globalConfig 
 
 def fosmMVAL( dim, g, dg, mus, sigmas ):
@@ -63,8 +64,8 @@ def fosmMVAL( dim, g, dg, mus, sigmas ):
         def wraps( x ):
             args[ var ] = x
             return func( args )
-        return misc.derivative( wraps, points[ var ], 
-                                dx=1 / np.power( 10, globalConfig.dtol ) )
+        return derivative( wraps, points[ var ], 
+                           dx=1 / np.power( 10, globalConfig.dtol ) )
     
     def dgWrap( g, var=0 ):
         def dgi( mus ):

--- a/src/ffpack/utils/generalUtils.py
+++ b/src/ffpack/utils/generalUtils.py
@@ -104,3 +104,148 @@ def sequenceDigitization( data, resolution=1.0 ):
     for d in data:
         rst.append( np.rint( d / resolution) * resolution )
     return rst
+
+
+def centralDiffWeights( Np, ndiv=1 ):
+    """
+    Return weights for an Np-point central derivative [1]_.
+
+    Assumes equally-spaced function points.
+
+    If weights are in the vector w, then
+    derivative is w[ 0 ] * f( x - ho * dx ) + ... + w[ -1 ] * f( x + h0 * dx )
+
+    Parameters
+    ----------
+    Np : integer
+        Number of points for the central derivative.
+    ndiv : integer, optional
+        Number of divisions. Default is 1.
+
+    Returns
+    -------
+    w : ndarray
+        Weights for an Np-point central derivative. Its size is `Np`.
+
+    Notes
+    -----
+    Can be inaccurate for a large number of points.
+    This function came from scipy.misc module, we put it here since scipy.misc module 
+    is completely removed in SciPy v1.12.0.
+
+    Examples
+    --------
+    >>> def f( x ):
+    ...     return 2 * x**2 + 3
+    >>> x = 3.0 # derivative point
+    >>> h = 0.1 # differential step
+    >>> Np = 3 # point number for central derivative
+    >>> weights = centralDiffWeights( Np ) # weights for first derivative
+    >>> vals = [ f( x + ( i - Np / 2 ) * h) for i in range( Np )]
+    >>> sum( w * v for (w, v) in zip( weights, vals ) ) / h
+    11.79999999999998
+    This value is close to the analytical solution:
+    f'(x) = 4x, so f'(3) = 12
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Finite_difference
+    """
+    if Np < ndiv + 1:
+        raise ValueError(
+            "Number of points must be at least the derivative order + 1."
+        )
+    if Np % 2 == 0:
+        raise ValueError( "The number of points must be odd." )
+    from scipy import linalg
+
+    ho = Np >> 1
+    x = np.arange(-ho, ho + 1.0)
+    x = x[ :, np.newaxis ]
+    X = x**0.0
+    for k in range( 1, Np ):
+        X = np.hstack( [ X, x**k ] )
+    w = np.prod( np.arange( 1, ndiv + 1 ), axis=0 ) * linalg.inv( X )[ ndiv ]
+    return w
+
+
+def derivative( func, x0, dx=1.0, n=1, args=(), order=3 ):
+    """
+    Find the nth derivative of a function at a point.
+
+    Given a function, use a central difference formula with spacing `dx` to
+    compute the nth derivative at `x0`.
+
+    Parameters
+    ----------
+    func : function
+        Input function.
+    x0 : float
+        The point at which the nth derivative is found.
+    dx : float, optional
+        Spacing.
+    n : int, optional
+        Order of the derivative. Default is 1.
+    args : tuple, optional
+        Arguments
+    order : int, optional
+        Number of points to use, must be odd.
+
+    Notes
+    -----
+    Decreasing the step size too small can result in round-off error.
+    This function came from scipy.misc module, we put it here since scipy.misc module 
+    is completely removed in SciPy v1.12.0.
+
+    Examples
+    --------
+    >>> def f(x):
+    ...     return x**3 + x**2
+    >>> _derivative( f, 1.0, dx=1e-6 )
+    4.9999999999217337
+    """
+
+    if order < n + 1:
+        raise ValueError(
+            "'order' (the number of points used to compute the derivative), "
+            "must be at least the derivative order 'n' + 1."
+        )
+
+    if order % 2 == 0:
+        raise ValueError(
+            "'order' (the number of points used to compute the derivative) "
+            "must be odd."
+        )
+    # pre-computed for n=1 and 2 and low-order for speed.
+    if n == 1:
+        if order == 3:
+            weights = np.array( [ -1, 0, 1 ] ) / 2.0
+        elif order == 5:
+            weights = np.array( [ 1, -8, 0, 8, -1 ] ) / 12.0
+        elif order == 7:
+            weights = np.array( [ -1, 9, -45, 0, 45, -9, 1 ] ) / 60.0
+        elif order == 9:
+            weights = np.array( [ 3, -32, 168, -672, 0, 672, -168, 32, -3 ] ) / 840.0
+        else:
+            weights = centralDiffWeights( order, 1 )
+    elif n == 2:
+        if order == 3:
+            weights = np.array( [ 1, -2.0, 1 ] )
+        elif order == 5:
+            weights = np.array( [ -1, 16, -30, 16, -1 ] ) / 12.0
+        elif order == 7:
+            weights = np.array( [ 2, -27, 270, -490, 270, -27, 2 ] ) / 180.0
+        elif order == 9:
+            weights = (
+                np.array( [ -9, 128, -1008, 8064, -14350, 
+                            8064, -1008, 128, -9 ] ) / 5040.0
+            )
+        else:
+            weights = centralDiffWeights( order, 2 )
+    else:
+        weights = centralDiffWeights( order, n )
+    val = 0.0
+    ho = order >> 1
+    for k in range( order ):
+        val += weights[ k ] * func( x0 + ( k - ho ) * dx, *args )
+    return val / np.prod( ( dx, ) * n, axis=0 )

--- a/tests/utils/test_utils_generalUtils.py
+++ b/tests/utils/test_utils_generalUtils.py
@@ -307,3 +307,112 @@ def test_digitizeSequenceToResolution_twoDimInputCase_valueError():
     data = [ [ 1.0, 2.5 ], [ 3.0, 4.5 ] ]
     with pytest.raises( ValueError ):
         _ = utils.sequenceDigitization( data, resolution=1.0 )
+
+
+
+###############################################################################
+# Test centralDiffWeights
+###############################################################################
+def test_centralDiffWeights_npLeNdivPlusOne_valueError():
+    Np = 5
+    ndiv = 5
+    with pytest.raises( ValueError ):
+        _ = utils.centralDiffWeights( Np, ndiv )
+
+    ndiv = 6
+    with pytest.raises( ValueError ):
+        _ = utils.centralDiffWeights( Np, ndiv )
+
+
+def test_centralDiffWeights_npIsEven_valueError():
+    Np = 4
+    ndiv = 1
+    with pytest.raises( ValueError ):
+        _ = utils.centralDiffWeights( Np, ndiv )
+
+
+@pytest.mark.parametrize( "Np", [ 3, 5, 7, 9 ])
+def test_centralDiffWeights_ndivIsOne_array( Np ):
+    ndiv = 1
+    expectedWeights = [ ]
+    if Np == 3:
+        expectedWeights = np.array( [ -1, 0, 1 ] ) / 2.0
+    elif Np == 5:
+        expectedWeights = np.array( [ 1, -8, 0, 8, -1 ] ) / 12.0
+    elif Np == 7:
+        expectedWeights = np.array( [ -1, 9, -45, 0, 45, -9, 1 ] ) / 60.0
+    elif Np == 9:
+        expectedWeights = np.array( [ 3, -32, 168, -672, 0, 
+                                      672, -168, 32, -3 ] ) / 840.0
+    
+    calWeights = utils.centralDiffWeights( Np, ndiv )
+    np.testing.assert_allclose( np.round( calWeights, 5 ), 
+                                np.round( expectedWeights, 5 ) )
+
+
+@pytest.mark.parametrize( "Np", [ 3, 5, 7, 9 ])
+def test_centralDiffWeights_ndivIsTwo_array( Np ):
+    ndiv = 2
+    expectedWeights = [ ]
+    if Np == 3:
+        expectedWeights = np.array( [ 1, -2.0, 1 ] )
+    elif Np == 5:
+        expectedWeights = np.array( [ -1, 16, -30, 16, -1 ] ) / 12.0
+    elif Np == 7:
+        expectedWeights = np.array( [ 2, -27, 270, -490, 270, -27, 2 ] ) / 180.0
+    elif Np == 9:
+        expectedWeights = np.array( [ -9, 128, -1008, 8064, -14350, 
+                                      8064, -1008, 128, -9 ] ) / 5040.0
+    
+    calWeights = utils.centralDiffWeights( Np, ndiv )
+    np.testing.assert_allclose( np.round( calWeights, 5 ), 
+                                np.round( expectedWeights, 5 ) )
+
+
+###############################################################################
+# Test derivative
+###############################################################################
+def test_derivative_orderLeNPlusOne_valueError():
+    f = lambda x: 2 * x 
+    with pytest.raises( ValueError ):
+        _ = utils.derivative( f, 1.0, dx=1e-6, n=3, order=3 )
+
+    with pytest.raises( ValueError ):
+        _ = utils.derivative( f, 1.0, dx=1e-6, n=4, order=3 )
+
+
+def test_derivative_orderIsEven_valueError():
+    f = lambda x: 2 * x 
+    with pytest.raises( ValueError ):
+        _ = utils.derivative( f, 1.0, dx=1e-6, order=4 )
+
+
+@pytest.mark.parametrize( "x0", np.linspace( -10, 10, 11 ) )
+def test_derivative_linearFun_scalar( x0 ):
+    f = lambda x: 2 * x 
+    df = lambda x: 2
+
+    calRst = utils.derivative( f, x0, dx=1e-6 )
+    expectedRst = df( x0 )
+    np.testing.assert_allclose( calRst, expectedRst )
+
+
+@pytest.mark.parametrize( "x0", np.linspace( -10, 10, 11 ) )
+def test_derivative_nonLinearFunCase1_scalar( x0 ):
+    f = lambda x: x ** 3 + 2 * x ** 2 + 7 * x
+    df = lambda x: 3 * x ** 2 + 4 * x + 7
+
+    calRst = utils.derivative( f, x0, dx=1e-6 )
+    expectedRst = df( x0 )
+    np.testing.assert_allclose( calRst, expectedRst )
+
+
+@pytest.mark.parametrize( "x0", np.linspace( -10, 10, 11 ) )
+def test_derivative_nonLinearFunCase2_scalar( x0 ):
+    f = lambda x: x ** 2 + 2 * np.exp( x ) + 7 * x
+    df = lambda x: 2 * x + 2 * np.exp( x ) + 7
+
+    calRst = utils.derivative( f, x0, dx=1e-6 )
+    expectedRst = df( x0 )
+    np.testing.assert_allclose( calRst, expectedRst )
+

--- a/tests/utils/test_utils_generalUtils.py
+++ b/tests/utils/test_utils_generalUtils.py
@@ -369,6 +369,7 @@ def test_centralDiffWeights_ndivIsTwo_array( Np ):
                                 np.round( expectedWeights, 5 ) )
 
 
+
 ###############################################################################
 # Test derivative
 ###############################################################################
@@ -415,4 +416,3 @@ def test_derivative_nonLinearFunCase2_scalar( x0 ):
     calRst = utils.derivative( f, x0, dx=1e-6 )
     expectedRst = df( x0 )
     np.testing.assert_allclose( calRst, expectedRst )
-


### PR DESCRIPTION
The `scipy.misc` module will be removed entirely in Scipy v1.12.0. The `derivative` function calculates the function derivative in many modules. 

We directly move the `derivative` function into the package so that no extra dependency is required for future release.