### PR TITLE
rrm/sormBreitung with formCOPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ pip install ffpack
 
 * Risk and reliability model
     * First order second moment
-        * fosm with mean value method
+        * FOSM with mean value method
     * First order reliability method
-        * form with Hasofer-Lind-Rackwitz-Fiessler method
-        * form with constrained optimization method
+        * FORM with Hasofer-Lind-Rackwitz-Fiessler method
+        * FORM with constrained optimization method
     * Second order reliability method
-        * sorm with Breitung method
+        * SORM with Breitung method
 
 * Utility methods
     * Derivative

--- a/src/ffpack/rrm/firstOrderReliabilityMethod.py
+++ b/src/ffpack/rrm/firstOrderReliabilityMethod.py
@@ -124,6 +124,10 @@ def formHLRF( dim, g, dg, distObjs, corrMat, iter=1000, tol=1e-6,
         if np.linalg.norm( Us[ idx ] - Us[ idx - 1 ] ) < tol:
             break
     
+    # We do not expect convergence with iter == 1
+    if iter != 1 and np.linalg.norm( Us[ idx ] - Us[ idx - 1 ] ) >= tol:
+        raise ValueError( "formHLRF does not converge with current parameters.")
+
     beta = betas[ idx ]
     pf = stats.norm.cdf( -beta )
     uCoord = Us[ idx ]

--- a/src/ffpack/rrm/firstOrderReliabilityMethod.py
+++ b/src/ffpack/rrm/firstOrderReliabilityMethod.py
@@ -132,7 +132,7 @@ def formHLRF( dim, g, dg, distObjs, corrMat, iter=1000, tol=1e-6,
     pf = stats.norm.cdf( -beta )
     uCoord = Us[ idx ]
     xCoord, _ = natafTrans.getX( uCoord )
-    return beta, pf, uCoord, xCoord
+    return beta, pf, uCoord.tolist(), xCoord.tolist()
 
 
 def formCOPT( dim, g, distObjs, corrMat, quadDeg=99, quadRange=8 ):
@@ -224,4 +224,4 @@ def formCOPT( dim, g, distObjs, corrMat, quadDeg=99, quadRange=8 ):
     pf = stats.norm.cdf( -beta )
     uCoord = rst.x
     xCoord = natafTrans.getX( uCoord )[ 0 ]
-    return beta, pf, uCoord, xCoord
+    return beta, pf, uCoord.tolist(), xCoord.tolist()

--- a/src/ffpack/rrm/secondOrderReliabilityMethod.py
+++ b/src/ffpack/rrm/secondOrderReliabilityMethod.py
@@ -7,8 +7,7 @@ from ffpack.rrm import firstOrderReliabilityMethod
 from ffpack import rpm
 
 
-def sormBreitung( dim, g, dg, distObjs, corrMat, iter=1000, tol=1e-6, 
-                  quadDeg=99, quadRange=8, dx=1e-6 ):
+def sormBreitung( dim, g, dg, distObjs, corrMat, quadDeg=99, quadRange=8, dx=1e-6 ):
     '''
     First order reliability method based on Breitung algorithm.
 
@@ -28,10 +27,6 @@ def sormBreitung( dim, g, dg, distObjs, corrMat, iter=1000, tol=1e-6,
         objects with pdf, cdf, ppf. We recommend to use scipy.stats functions.
     corrMat: 2d matrix
         Correlation matrix of the marginal distributions.
-    iter: integer
-        Maximum iteration steps.
-    tol: scalar
-        Tolerance to demtermine if the iteration converges.
     quadDeg: integer
         Quadrature degree for Nataf transformation
     quadRange: scalar
@@ -100,7 +95,7 @@ def sormBreitung( dim, g, dg, distObjs, corrMat, iter=1000, tol=1e-6,
         raise ValueError( "corrMat should be positive definite" )
 
     beta, _, uCoord, xCoord = firstOrderReliabilityMethod.\
-        formHLRF( dim, g, dg, distObjs, corrMat, iter, tol, quadDeg, quadRange, dx )
+        formCOPT( dim, g, distObjs, corrMat, quadDeg, quadRange )
 
     natafTrans = rpm.NatafTransformation( distObjs=distObjs, corrMat=corrMat, 
                                           quadDeg=quadDeg, quadRange=quadRange )

--- a/src/ffpack/utils/miscUtils.py
+++ b/src/ffpack/utils/miscUtils.py
@@ -176,7 +176,8 @@ def gradient( func, nvar, n=1, dx=1e-3, order=3 ):
         in the list is the n-th derivative of the func w.r.t. i-th input variable. 
         Therefore, rst[ i ] = :math:`\partial^n f / \partial X_i^n` and it can be
         called like rst[ i ]( X0 ) to evaluate the n-th derivative w.r.t. 
-        i-th variable at point X0.
+        i-th variable at point X0. It should be noted that X0 MUST be a list, NOT a
+        numpy array.
 
     Notes
     -----
@@ -253,7 +254,8 @@ def hessianMatrix( func, nvar, dx=1e-3, order=3 ):
     rst : 2d array
         Hessian matrix. rst[ i ][ j ] = :math:`\partial f / 
         ( \partial X_i \partial X_j )`.  It can be called like rst[ i ][ j ]( X0 ) 
-        to evaluate the value at point X0.
+        to evaluate the value at point X0. It should be noted that X0 MUST be a list, 
+        NOT a numpy array.
 
     Notes
     -----

--- a/tests/rrm/test_rrm_firstOrderReliabilityMethod.py
+++ b/tests/rrm/test_rrm_firstOrderReliabilityMethod.py
@@ -115,6 +115,21 @@ def test_formHLRF_corrMatDiagNotOneCase_valueError( ):
         _, _, _, _ = rrm.formHLRF( dim, g, dg, distObjs, corrMat )
 
 
+def test_formHLRF_notConverge_valueError():
+    dim = 2
+
+    def g( X ):
+        return X[ 0 ] ** 4 + 2 * X[ 1 ] ** 4 - 20
+
+    dg = [ lambda X: 4 * X[ 0 ] ** 3, lambda X: 8 * X[ 1 ] ** 3 ] 
+    X1 = stats.norm( loc=10.0, scale=5.0 )
+    X2 = stats.norm( loc=10.0, scale=5.0 )
+    distObjs = [ X1, X2 ]
+    corrMat = np.eye( dim )
+    with pytest.raises( ValueError ):
+        _, _, _, _ = rrm.formHLRF( dim, g, dg, distObjs, corrMat, iter=100 )
+
+
 @pytest.mark.parametrize( "dgExists", [ 0, 1 ] )
 @patch.object( NatafTransformation, 'getX' )
 def test_formHLRF_twoNormalLinearMockCase1_scalar( mock_getX, dgExists ):
@@ -278,6 +293,58 @@ def test_formHLRF_twoNormalNonLinearCase2_scalar( dgExists ):
                                 np.round( calUCoord, 4 ) )
     np.testing.assert_allclose( np.round( expectedXCoord, 4 ), 
                                 np.round( calXCoord, 4 ) )
+
+
+@pytest.mark.parametrize( "dgExists", [ 0, 1 ] )
+def test_formHLRF_twoNormalNonLinearCase3_scalar( dgExists ):
+    dim = 2
+
+    def g( X ):
+        return X[ 0 ] ** 2 + 2 * X[ 1 ] ** 2 - 20
+
+    dg = [ lambda X: 2 * X[ 0 ], lambda X: 4 * X[ 1 ] ] if dgExists else None
+    X1 = stats.norm( loc=5.0, scale=5.0 )
+    X2 = stats.norm( loc=5.0, scale=5.0 )
+    distObjs = [ X1, X2 ]
+    corrMat = np.eye( dim )
+    calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, 
+                                                         distObjs, corrMat )
+    expectedBeta = 0.6636720072645971
+    expectedPf = stats.norm.cdf( -expectedBeta )
+    expectedUCoord = [ -0.37621928, -0.54673539 ]
+    expectedXCoord = [ 3.11890359, 2.26632306 ]
+    np.testing.assert_allclose( np.round( expectedBeta, 5 ), np.round( calBeta, 5 ) )
+    np.testing.assert_allclose( np.round( expectedPf, 5 ), np.round( calPf, 5 ) )
+    np.testing.assert_allclose( np.round( expectedUCoord, 4 ), 
+                                np.round( calUCoord, 4 ) )
+    np.testing.assert_allclose( np.round( expectedXCoord, 4 ), 
+                                np.round( calXCoord, 4 ) )
+
+
+@pytest.mark.parametrize( "dgExists", [ 0, 1 ] )
+def test_formHLRF_twoNormalNonLinearCase4_scalar( dgExists ):
+    dim = 2
+
+    def g( X ):
+        return X[ 0 ] ** 2 + 2 * X[ 1 ] ** 2 - 20
+
+    dg = [ lambda X: 2 * X[ 0 ], lambda X: 4 * X[ 1 ] ] if dgExists else None
+    X1 = stats.norm( loc=3.0, scale=6.0 )
+    X2 = stats.norm( loc=4.0, scale=5.0 )
+    distObjs = [ X1, X2 ]
+    corrMat = np.eye( dim )
+    calBeta, calPf, calUCoord, calXCoord = rrm.formHLRF( dim, g, dg, 
+                                                         distObjs, corrMat )
+    expectedBeta = 0.28257129279933346
+    expectedPf = stats.norm.cdf( -expectedBeta )
+    expectedUCoord = [ -0.12510462, -0.25336805 ]
+    expectedXCoord = [ 2.2493723, 2.73315974 ]
+    np.testing.assert_allclose( np.round( expectedBeta, 5 ), np.round( calBeta, 5 ) )
+    np.testing.assert_allclose( np.round( expectedPf, 5 ), np.round( calPf, 5 ) )
+    np.testing.assert_allclose( np.round( expectedUCoord, 3 ), 
+                                np.round( calUCoord, 3 ) )
+    np.testing.assert_allclose( np.round( expectedXCoord, 3 ), 
+                                np.round( calXCoord, 3 ) )
 
 
 @pytest.mark.parametrize( "dgExists", [ 0, 1 ] )
@@ -620,6 +687,52 @@ def test_formCOPT_twoNormalNonLinearCase2_scalar():
                                 np.round( calXCoord, 3 ) )
 
 
+def test_formCOPT_twoNormalNonLinearCase3_scalar():
+    dim = 2
+
+    def g( X ):
+        return X[ 0 ] ** 2 + 2 * X[ 1 ] ** 2 - 20
+
+    X1 = stats.norm( loc=5.0, scale=5.0 )
+    X2 = stats.norm( loc=5.0, scale=5.0 )
+    distObjs = [ X1, X2 ]
+    corrMat = np.eye( dim )
+    calBeta, calPf, calUCoord, calXCoord = rrm.formCOPT( dim, g, distObjs, corrMat )
+    expectedBeta = 0.6636720072645971
+    expectedPf = stats.norm.cdf( -expectedBeta )
+    expectedUCoord = [ -0.37621928, -0.54673539 ]
+    expectedXCoord = [ 3.11890359, 2.26632306 ]
+    np.testing.assert_allclose( np.round( expectedBeta, 5 ), np.round( calBeta, 5 ) )
+    np.testing.assert_allclose( np.round( expectedPf, 5 ), np.round( calPf, 5 ) )
+    np.testing.assert_allclose( np.round( expectedUCoord, 4 ), 
+                                np.round( calUCoord, 4 ) )
+    np.testing.assert_allclose( np.round( expectedXCoord, 4 ), 
+                                np.round( calXCoord, 4 ) )
+
+
+def test_formCOPT_twoNormalNonLinearCase4_scalar():
+    dim = 2
+
+    def g( X ):
+        return X[ 0 ] ** 2 + 2 * X[ 1 ] ** 2 - 20
+
+    X1 = stats.norm( loc=3.0, scale=6.0 )
+    X2 = stats.norm( loc=4.0, scale=5.0 )
+    distObjs = [ X1, X2 ]
+    corrMat = np.eye( dim )
+    calBeta, calPf, calUCoord, calXCoord = rrm.formCOPT( dim, g, distObjs, corrMat )
+    expectedBeta = 0.28257129279933346
+    expectedPf = stats.norm.cdf( -expectedBeta )
+    expectedUCoord = [ -0.12510462, -0.25336805 ]
+    expectedXCoord = [ 2.2493723, 2.73315974 ]
+    np.testing.assert_allclose( np.round( expectedBeta, 5 ), np.round( calBeta, 5 ) )
+    np.testing.assert_allclose( np.round( expectedPf, 5 ), np.round( calPf, 5 ) )
+    np.testing.assert_allclose( np.round( expectedUCoord, 3 ), 
+                                np.round( calUCoord, 3 ) )
+    np.testing.assert_allclose( np.round( expectedXCoord, 3 ), 
+                                np.round( calXCoord, 3 ) )
+
+
 def test_formCOPT_threeExpLinearCase_scalar():
     dim = 3
 
@@ -764,3 +877,4 @@ def test_formCOPT_twoExpOneNormalOneGammaNonLinearCase_scalar():
                                 np.round( calUCoord, 3 ) )
     np.testing.assert_allclose( np.round( expectedXCoord, 3 ), 
                                 np.round( calXCoord, 3 ) )
+

--- a/tests/rrm/test_rrm_secondOrderReliabilityMethod.py
+++ b/tests/rrm/test_rrm_secondOrderReliabilityMethod.py
@@ -136,7 +136,7 @@ def test_sormBreitung_twoNormalLinearCase_scalar( dgExists ):
     expectedUCoord = [ 0.5, 0.5 ]
     expectedXCoord = [ 0.5, 0.5 ]
     np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
-    np.testing.assert_allclose( np.round( expectedPf, 4 ), np.round( calPf, 4 ) )
+    np.testing.assert_allclose( np.round( expectedPf, 3 ), np.round( calPf, 3 ) )
     np.testing.assert_allclose( np.round( expectedUCoord, 4 ), 
                                 np.round( calUCoord, 4 ) )
     np.testing.assert_allclose( np.round( expectedXCoord, 4 ), 
@@ -144,17 +144,21 @@ def test_sormBreitung_twoNormalLinearCase_scalar( dgExists ):
 
 
 @pytest.mark.parametrize( "dgExists", [ 0, 1 ] )
-@patch( "ffpack.rrm.firstOrderReliabilityMethod.formHLRF" )
-def test_sormBreitung_twoNormalNonLinearCase_scalar( mock_formHLRF, dgExists ):
+def test_sormBreitung_twoNormalNonLinearCase_scalar( dgExists ):
     r'''
-    This example come from the reference [Choi2007] page 132.
+    This example comes from the reference [Choi2007] page 132.
 
     Here are some expected values of local variables from the refernce:
+
     lsfGradAtU = [ 119.8184, 124.8218 ]
     lsfHmAtU = [ [ 989.5592, 0 ],
                  [ 0, 1281.2632 ] ]
     HBH = [ [ 6.5278, -0.8423 ],
             [ -0.8423, 6.5968 ] ]
+
+    Notes
+    -----
+    formHLRF does not converge for this high order limit state function.
 
     References
     ----------
@@ -172,10 +176,13 @@ def test_sormBreitung_twoNormalNonLinearCase_scalar( mock_formHLRF, dgExists ):
     X2 = stats.norm( loc=10.0, scale=5.0 )
     distObjs = [ X1, X2 ]
     corrMat = np.eye( dim )
-    mock_formHLRF.return_value = [ 2.3654, stats.norm.cdf( -2.3654 ),
-                                   [ -1.6368, -1.7077 ], [ 1.8162, 1.4613 ] ]
-    calBeta, calPf, _, _ = rrm.sormBreitung( dim, g, dg, distObjs, corrMat )
+    calBeta, calPf, calUCoord, calXCoord = rrm.sormBreitung( dim, g, dg, 
+                                                             distObjs, corrMat )
     expectedBeta = 2.3654
     expectedPf = 0.00222059
-    np.testing.assert_allclose( np.round( expectedBeta, 4 ), np.round( calBeta, 4 ) )
-    np.testing.assert_allclose( np.round( expectedPf, 4 ), np.round( calPf, 4 ) )
+    expectedUCoord = [ -1.6368, -1.7077 ]
+    expectedXCoord = [ 1.8162, 1.4613 ]
+    np.testing.assert_allclose( expectedBeta, calBeta, atol=1e-4 )
+    np.testing.assert_allclose( expectedPf, calPf, atol=1e-4 )
+    np.testing.assert_allclose( expectedUCoord, calUCoord, atol=1e-3 )
+    np.testing.assert_allclose( expectedXCoord, calXCoord, atol=1e-3 )


### PR DESCRIPTION
Updated sormBreitung with formCOPT function.
Remove the test patch for sormBreitung function.